### PR TITLE
Added continous integration with travis.ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+sudo: required
+
+language: cpp
+
+services:
+  - docker
+
+before_install:
+- docker pull schubertkonstantin/cern_root:v5-34-23
+
+script:
+- docker run schubertkonstantin/cern_root:v5-34-23  /bin/bash -c "git clone https://github.com/gammacombo/gammacombo.git; cd gammacombo; mkdir build; cd build; cmake ..; make; make install"


### PR DESCRIPTION
I added continous integration with travis.ci.
If you would rather have me fork and request a pull to the development branch, just let me know.

The complete necessary configurations lives in the travis.yml.
If I am added to get gammacombo organization it should be possible to use my account on travis.org. Otherwise we might use somebody elese's.
