### PR TITLE
change tutorial a_obs of gaus 1 for consistency

### DIFF
--- a/tutorial/src/PDF_Gaus.cpp
+++ b/tutorial/src/PDF_Gaus.cpp
@@ -57,7 +57,7 @@ void PDF_Gaus::setObservables(TString c)
 	}
 	else if ( c.EqualTo("year2013") ){
 		obsValSource = c;
-		setObservable("a_gaus_obs",-1.5);
+		setObservable("a_gaus_obs",-0.5);
 	}
 	else if ( c.EqualTo("year2014") ){
 		obsValSource = c;


### PR DESCRIPTION
Contradictory to output and documentation, the value of a_obs was set to -1.5 (for testing in an old commit I guess). Reset it to -0.5 to avoid irritation