### PR TITLE
manage size of toy dataset when generating while doing the plugin scan

### DIFF
--- a/core/src/PDF_Datasets.cpp
+++ b/core/src/PDF_Datasets.cpp
@@ -263,7 +263,7 @@ RooFitResult* PDF_Datasets::fit(RooDataSet* dataToFit) {
 void   PDF_Datasets::generateToys(int SeedShift) {
 
     initializeRandomGenerator(SeedShift);
-    RooDataSet* toys = this->pdf->generate(*observables, RooFit::Extended(kTRUE));
+    RooDataSet* toys = this->pdf->generate(*observables, RooFit::NumEvents(wspc->data(dataName)->numEntries()), RooFit::Extended(kTRUE));
 
     // Having the delete in here causes a segmentation fault, likely due to a double free
     // related to Root's internal memory management. Therefore we do not delete,


### PR DESCRIPTION
When trying the Bs24mu case, I discovered a rapidly increasing number of toy events in one toy dataset when generating the toy datasets during the plugin scan, eventually leading to a SegFault. It seems like RooFit always generated toy datasets with a number of events poisson distributed around the number of events of the previous generation.

The change now tells the generator to generate toy datasets with a size that is poisson distributed, where the mean is the size of the original dataset (for which the CI is to be determined). 
This fixes the SegFault and I think that is what is supposed to happen.