### PR TITLE
fix: cls with combination

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,9 +28,15 @@ script:
   docker run built_image_6 /bin/bash -c "
       cd /code/tutorial;
       bin/tutorial_dataset_build_workspace;
-      bin/tutorial_dataset --var branchingRatio --scanrange 0:15e-7 --npoints 5;
+      bin/tutorial_dataset --var branchingRatio --scanrange 0:15e-7 --npoints 5 --cls 1;
       bin/tutorial_dataset -a pluginbatch --var branchingRatio --ntoys 5 --scanrange 0:15e-7 --npoints 5 --npointstoy 5;
-      bin/tutorial_dataset -a plugin --var branchingRatio --scanrange 0:15e-7 --npoints 5 --npointstoy 5 --nrun 1
+      bin/tutorial_dataset -a plugin --var branchingRatio --scanrange 0:15e-7 --npoints 5 --npointstoy 5 --nrun 1 --cls 1 --cls 2
+      "
+  docker run built_image_6 /bin/bash -c "
+      cd /code/tutorial;
+      bin/tutorial_dataset_build_workspace;
+      bin/tutorial_dataset --var branchingRatio --scanrange 0:15e-7 --npoints 5 --cls 1;
+      bin/tutorial_dataset --var branchingRatio --var exponent --npoints2dx 5 --npoints2dy 5 --scanrange 0.:1e-6 --scanrangey -1.1e-3:-0.9e-3
       "
 # root5
 - docker run --name raw_container schubertkonstantin/root:v5-34-32 /bin/bash -c "mkdir /code"

--- a/core/src/GammaComboEngine.cpp
+++ b/core/src/GammaComboEngine.cpp
@@ -1024,16 +1024,17 @@ void GammaComboEngine::make1dProbPlot(MethodProbScan *scanner, int cId)
 {
 	if (!arg->isAction("pluginbatch") && !arg->plotpluginonly){
 		scanner->setDrawSolution(arg->plotsolutions[cId]);
-    if ( arg->cls.size()>0 ) {
-      ((MethodDatasetsProbScan*)scanner)->plotFitRes(m_fnamebuilder->getFileNamePlot(cmb)+"_fit");
-      scanner->plotOn(plot, 1); // for prob ClsType>1 doesn't exist
-    }
+    	if ( arg->cls.size()>0 && runOnDataSet) {
+      		((MethodDatasetsProbScan*)scanner)->plotFitRes(m_fnamebuilder->getFileNamePlot(cmb)+"_fit");
+      		scanner->plotOn(plot, 1); // for prob ClsType>1 doesn't exist
+    	}
+    	if( arg->cls.size()>0) scanner->plotOn(plot, 1); // for prob ClsType>1 doesn't exist
 		scanner->plotOn(plot);
 		int colorId = cId;
 		if ( arg->color.size()>cId ) colorId = arg->color[cId];
 		scanner->setLineColor(colorsLine[colorId]);
 		scanner->setTextColor(colorsText[colorId]);
-    scanner->setFillStyle(fillStyles[cId]);
+    	scanner->setFillStyle(fillStyles[cId]);
 		plot->Draw();
 	}
 }

--- a/core/src/MethodAbsScan.cpp
+++ b/core/src/MethodAbsScan.cpp
@@ -654,10 +654,10 @@ void MethodAbsScan::calcCLintervals(int CLsType)
  		this->calcCLintervalsSimple(CLsType);
 		return;
 	}
-	// else if((CLsType==1||CLsType==2) && !this->getHCLs()) {
-	// 	cout<<"Using simple method with  linear splines."<<endl;
-	// 	this->calcCLintervalsSimple(CLsType);
-	// }
+	else if((CLsType==1||CLsType==2) && !this->getHCLs()) {
+		cout<<"Using simple method with  linear splines."<<endl;
+		this->calcCLintervalsSimple(CLsType);
+	}
 
   if ( arg->debug ) cout << "MethodAbsScan::calcCLintervals() : ";
   cout << "CONFIDENCE INTERVALS for combination " << name << endl << endl;
@@ -1466,8 +1466,6 @@ void MethodAbsScan::calcCLintervalsSimple(int CLsType)
 		cout << ", " << methodName << " (simple boundary scan)" << endl;
 	  }
 	}
-
-
 	////////////////////////////////////////////////////////////////////////////////////////////
 	//// Add a hacky calculation of the CL_s intervals
 	//// \todo: Do it properly from the very start by introducing a bkg model and propagate it to the entire framework.


### PR DESCRIPTION
It's done. Finally.

There is no plotting of the cls method using the combination, since it's only a hacky method. One could think about filling the hCLs histogram in the `get_bordersCLs` method. But not planned yet.

Please check the plugin cls method with the combination before 
merging.

CLs for the combination in 2d is not supported right now. That will need a comment eventually. But I think we are ready for the merge now.