### PR TITLE
BUGFIX: Fallback implemented when polynomial interpolation fails

### DIFF
--- a/core/src/MethodAbsScan.cpp
+++ b/core/src/MethodAbsScan.cpp
@@ -577,6 +577,12 @@ bool MethodAbsScan::interpolate(TH1F* h, int i, float y, float central, bool upp
 	float sol1 = pq(p[0], p[1], p[2], y, 1);
 	// cout << upper << " ";
 	// printf("%f %f %f\n", central, sol0, sol1);
+	if(h->GetBinCenter(i-2) > sol0 || sol0 > h->GetBinCenter(i+2) || h->GetBinCenter(i-2) > sol1 || sol1 > h->GetBinCenter(i+2))
+	{
+		cout << "Polynomial interpolation out of bounds." << endl;
+		return false;
+	}
+
 	int useSol = 0;
 
 	if ( (sol0<central && sol1>central) || (sol1<central && sol0>central) )
@@ -674,7 +680,7 @@ void MethodAbsScan::calcCLintervals(int CLsType)
 
 	clintervals1sigma.clear(); // clear, else calling this function twice doesn't work
 	clintervals2sigma.clear();
-  clintervals3sigma.clear();
+  	clintervals3sigma.clear();
 	int n = histogramCL->GetNbinsX();
 	RooRealVar* par = w->var(scanVar1);
 
@@ -699,6 +705,7 @@ void MethodAbsScan::calcCLintervals(int CLsType)
 				if ( histogramCL->GetBinContent(i) < y ){
 					if ( n>25 ){
 						bool check = interpolate(histogramCL, i, y, sol, false, CLlo[c], CLloErr[c]);
+						if(!check) cout << "Using linear interpolation." << endl;
 						if ( !check || CLlo[c]!=CLlo[c] ) interpolateSimple(histogramCL, i, y, CLlo[c]);
 					}
 					else{
@@ -713,7 +720,8 @@ void MethodAbsScan::calcCLintervals(int CLsType)
 				if ( histogramCL->GetBinContent(i) < y ){
 					if ( n>25 ){
 						bool check = interpolate(histogramCL, i-1, y, sol, true, CLhi[c], CLhiErr[c]);
-						if ( CLhi[c]!=CLhi[c] ) interpolateSimple(histogramCL, i-1, y, CLhi[c]);
+						if(!check) cout << "Using linear interpolation." << endl;
+						if (!check || CLhi[c]!=CLhi[c] ) interpolateSimple(histogramCL, i-1, y, CLhi[c]);
 					}
 					else{
 						interpolateSimple(histogramCL, i-1, y, CLhi[c]);

--- a/core/src/OneMinusClPlot.cpp
+++ b/core/src/OneMinusClPlot.cpp
@@ -156,7 +156,7 @@ TGraph* OneMinusClPlot::scan1dPlot(MethodAbsScan* s, bool first, bool last, bool
 			g->SetMarkerSize(1);
 		}
 		if(CLsType==2) {
-			g->SetMarkerStyle(21);
+			g->SetMarkerStyle(25);
 		}
 	}
 


### PR DESCRIPTION
I encountered some strange results (values `~1e26` when `~1e-9` expected) from the polynomial interpolation, always accompanied with warning messages like 
```Error in <TDecompChol::Solve(TVectorD &b)>: u[2,2]=2.1552e-21 < 2.2204e-16
Error in <TLinearFitter::Eval>: Matrix inversion failed
Warning in <Minimize>: TLinearFitter failed in finding the solution
```

So I implemented to fall back to the linear interpolation when the polynomial interpolation runs out of bounds.
@matthewkenzie should at least be aware of this, since it affects a very core part of GC.
