### PR TITLE
allow user specific CL #158

### DIFF
--- a/core/include/MethodAbsScan.h
+++ b/core/include/MethodAbsScan.h
@@ -149,6 +149,7 @@ class MethodAbsScan
 		vector<CLInterval> clintervals1sigma;           ///< all 1 sigma intervals that were found by calcCLintervals()
 		vector<CLInterval> clintervals2sigma;           ///< all 2 sigma intervals that were found by calcCLintervals()
 		vector<CLInterval> clintervals3sigma;           ///< all 3 sigma intervals that were found by calcCLintervals()
+		vector<CLInterval> clintervalsuser;           ///< all intervals with user specific CL that were found by calcCLintervals()
 
 	protected:
 
@@ -206,6 +207,7 @@ class MethodAbsScan
 		bool m_xrangeset; 			///< true if the x range was set manually (setXscanRange())
 		bool m_yrangeset; 			///< true if the y range was set manually (setYscanRange())
 		bool m_initialized; 		///< true if initScan() was called
+		double CLuser;
 
 	private:
 

--- a/core/include/MethodAbsScan.h
+++ b/core/include/MethodAbsScan.h
@@ -146,10 +146,13 @@ class MethodAbsScan
 		vector<vector<RooSlimFitResult*> > curveResults2d;  ///< All fit results of the the points that make it into the 1-CL curve.
 		///< Index is the gobal bin number of hCL2d -1.
 		vector<RooSlimFitResult*> solutions;            ///< Local minima filled by saveSolutions() and saveSolutions2d().
+
+		///< The names of the CL interval vectors might be misleading. They correspond to the default CL intervals. 
+		///< If the option --CL is given, the 1-3 sigma correspond to the first, second,... given value of the CL.
 		vector<CLInterval> clintervals1sigma;           ///< all 1 sigma intervals that were found by calcCLintervals()
 		vector<CLInterval> clintervals2sigma;           ///< all 2 sigma intervals that were found by calcCLintervals()
 		vector<CLInterval> clintervals3sigma;           ///< all 3 sigma intervals that were found by calcCLintervals()
-		vector<CLInterval> clintervalsuser;           ///< all intervals with user specific CL that were found by calcCLintervals()
+		vector<CLInterval> clintervalsuser;           ///< all intervals with an additional user specific CL that were found by calcCLintervals()
 
 	protected:
 

--- a/core/include/MethodAbsScan.h
+++ b/core/include/MethodAbsScan.h
@@ -207,7 +207,7 @@ class MethodAbsScan
 		bool m_xrangeset; 			///< true if the x range was set manually (setXscanRange())
 		bool m_yrangeset; 			///< true if the y range was set manually (setYscanRange())
 		bool m_initialized; 		///< true if initScan() was called
-		double CLuser;
+		std::vector<double> ConfidenceLevels;	///< container of the confidence levels to be computed
 
 	private:
 

--- a/core/include/OneMinusClPlot.h
+++ b/core/include/OneMinusClPlot.h
@@ -34,10 +34,10 @@ class OneMinusClPlot : public OneMinusClPlotAbs
 		void            drawVerticalLine(float x, int color, int style);
 		TGraph*         scan1dPlot(MethodAbsScan* s, bool first, bool last, bool filled, int CLsType=0);
 		void            scan1dPlotSimple(MethodAbsScan* s, bool first, int CLsType=0);
-    void            scan1dCLsPlot(MethodAbsScan *s, bool smooth=true, bool obsError=true);
+    	void            scan1dCLsPlot(MethodAbsScan *s, bool smooth=true, bool obsError=true);
 
 		bool            plotPluginMarkers;
-    TCanvas         *m_clsCanvas;
+    	TCanvas         *m_clsCanvas;
 };
 
 #endif

--- a/core/include/OptParser.h
+++ b/core/include/OptParser.h
@@ -40,6 +40,7 @@ class OptParser
 		vector<int>		asimov;
 		vector<TString> asimovfile;
 		bool			cacheStartingValues;
+		vector<float>	CL;
 		vector<int>		cls;
 		vector<int>		color;
 		vector<int>		combid;

--- a/core/src/MethodAbsScan.cpp
+++ b/core/src/MethodAbsScan.cpp
@@ -581,7 +581,7 @@ bool MethodAbsScan::interpolate(TH1F* h, int i, float y, float central, bool upp
 	// printf("%f %f %f\n", central, sol0, sol1);
 	if(h->GetBinCenter(i-2) > sol0 || sol0 > h->GetBinCenter(i+2) || h->GetBinCenter(i-2) > sol1 || sol1 > h->GetBinCenter(i+2))
 	{
-		cout << "Polynomial interpolation out of bounds." << endl;
+		if(arg->verbose || arg->debug) cout << "Polynomial interpolation out of bounds." << endl;
 		return false;
 	}
 
@@ -709,7 +709,7 @@ void MethodAbsScan::calcCLintervals(int CLsType)
 				if ( histogramCL->GetBinContent(i) < y ){
 					if ( n>25 ){
 						bool check = interpolate(histogramCL, i, y, sol, false, CLlo[c], CLloErr[c]);
-						if(!check) cout << "Using linear interpolation." << endl;
+						if(!check && (arg->verbose ||arg->debug)) cout << "Using linear interpolation." << endl;
 						if ( !check || CLlo[c]!=CLlo[c] ) interpolateSimple(histogramCL, i, y, CLlo[c]);
 					}
 					else{
@@ -724,7 +724,7 @@ void MethodAbsScan::calcCLintervals(int CLsType)
 				if ( histogramCL->GetBinContent(i) < y ){
 					if ( n>25 ){
 						bool check = interpolate(histogramCL, i-1, y, sol, true, CLhi[c], CLhiErr[c]);
-						if(!check) cout << "Using linear interpolation." << endl;
+						if(!check && (arg->verbose ||arg->debug)) cout << "Using linear interpolation." << endl;
 						if (!check || CLhi[c]!=CLhi[c] ) interpolateSimple(histogramCL, i-1, y, CLhi[c]);
 					}
 					else{

--- a/core/src/MethodAbsScan.cpp
+++ b/core/src/MethodAbsScan.cpp
@@ -699,10 +699,10 @@ void MethodAbsScan::calcCLintervals(int CLsType)
 	for ( int iSol=0; iSol<solutions.size(); iSol++ )
 	{
 		const int NumOfCL = ConfidenceLevels.size();
-		float CLhi[NumOfCL]    = {0.0};
-		float CLhiErr[NumOfCL] = {0.0};
-		float CLlo[NumOfCL]    = {0.0};
-		float CLloErr[NumOfCL] = {0.0};
+		std::vector<float> CLhi(NumOfCL, 0.0);
+		std::vector<float> CLhiErr(NumOfCL, 0.0);
+		std::vector<float> CLlo(NumOfCL, 0.0);
+		std::vector<float> CLloErr(NumOfCL, 0.0);
 
 		for ( int c=0; c<NumOfCL; c++ )
 		{
@@ -787,10 +787,10 @@ void MethodAbsScan::calcCLintervals(int CLsType)
 	for ( int iBoundary=0; iBoundary<2; iBoundary++ )
 	{
 		const int NumOfCL = ConfidenceLevels.size();
-		float CLhi[NumOfCL]    = {0.0};
-		float CLhiErr[NumOfCL] = {0.0};
-		float CLlo[NumOfCL]    = {0.0};
-		float CLloErr[NumOfCL] = {0.0};
+		std::vector<float> CLhi(NumOfCL, 0.0);
+		std::vector<float> CLhiErr(NumOfCL, 0.0);
+		std::vector<float> CLlo(NumOfCL, 0.0);
+		std::vector<float> CLloErr(NumOfCL, 0.0);
 
 		for ( int c=0; c<NumOfCL; c++ )
 		{

--- a/core/src/OneMinusClPlot.cpp
+++ b/core/src/OneMinusClPlot.cpp
@@ -711,13 +711,28 @@ void OneMinusClPlot::drawCLguideLine(float pvalue)
 ///
 void OneMinusClPlot::drawCLguideLines()
 {
-	drawCLguideLine(0.3173);
-	drawCLguideLine(4.55e-2);
-	if ( arg->plotlog ){
-		drawCLguideLine(2.7e-3);
-		if ( arg->plotymin < 6.3e-5 ) {
-      drawCLguideLine(6.3e-5);
-    }
+	if ( arg->CL.size()==0){
+		drawCLguideLine(0.3173);
+		drawCLguideLine(4.55e-2);
+		if ( arg->plotlog ){
+			drawCLguideLine(2.7e-3);
+			if ( arg->plotymin < 6.3e-5 ) {
+	      		drawCLguideLine(6.3e-5);
+	    	}
+		}
+	}
+	if ( arg->CL.size()>0){
+		for ( auto level : arg->CL ){
+			if ( level < 99 ){
+				drawCLguideLine(1. - level/100.);
+			}
+			else if ( arg->plotlog ){
+				if ( arg->plotymin > 6.3e-5 && level < 99.9937){
+					continue;
+				}
+				drawCLguideLine(1. - level/100.);
+			}
+		}
 	}
 }
 

--- a/core/src/OptParser.cpp
+++ b/core/src/OptParser.cpp
@@ -126,6 +126,7 @@ void OptParser::defineOptions()
 	availableOptions.push_back("asimovfile");
   availableOptions.push_back("batchstartn");
   availableOptions.push_back("batcheos");
+	availableOptions.push_back("CL");
 	availableOptions.push_back("cls");
 	availableOptions.push_back("combid");
 	availableOptions.push_back("color");
@@ -518,6 +519,12 @@ void OptParser::parseArguments(int argc, char* argv[])
 			, false, "int");
 	TCLAP::MultiArg<int> colorArg("", "color", "ID of color to be used for the combination. "
 			"Default: 0 for first scanner, 1 for second, etc.", false, "int");
+	 TCLAP::MultiArg<float> CLArg("", "CL", "Confidence Levels to be computed and plotted in percent. This argument can be passed multiple times.\n"
+     "Default will print 1 & 2 (3) sigma confidence levels\n"
+     "Syntax: --CL 90  \n"
+     "alternative: -cl 95.45  \n"
+     , false, "float");
+
   TCLAP::MultiArg<int> clsArg("", "cls", "Types of CLs to be plotted.\n"
       "Default will not do anything\n"
       "1: Naive CLs (assuming CLb is obtained from the point at zero)\n"
@@ -748,6 +755,7 @@ void OptParser::parseArguments(int argc, char* argv[])
 	if ( isIn<TString>(bookedOptions, "combid" ) ) cmd.add(combidArg);
 	if ( isIn<TString>(bookedOptions, "color" ) ) cmd.add(colorArg);
 	if ( isIn<TString>(bookedOptions, "cls" ) ) cmd.add(clsArg);
+	if ( isIn<TString>(bookedOptions, "CL" ) ) cmd.add(CLArg);
   if ( isIn<TString>(bookedOptions, "batchstartn" ) ) cmd.add( batchstartnArg );
   if ( isIn<TString>(bookedOptions, "batcheos" ) ) cmd.add(batcheosArg);
 	if ( isIn<TString>(bookedOptions, "asimovfile" ) ) cmd.add( asimovFileArg );
@@ -760,6 +768,7 @@ void OptParser::parseArguments(int argc, char* argv[])
 	//
 	asimov            = asimovArg.getValue();
 	cls 			  = clsArg.getValue();
+	CL 			  	  = CLArg.getValue();
 	color             = colorArg.getValue();
 	controlplot       = controlplotArg.getValue();
   confirmsols       = ! noconfsolsArg.getValue();
@@ -1214,6 +1223,12 @@ void OptParser::parseArguments(int argc, char* argv[])
 		cout << "ERROR : --po can only be given when -a plugin is set." << endl;
 		exit(1);
 	}
+
+	// check --CL argument
+	if ( var.size()>1 && CL.size()>0){
+		std::cout << "ERROR: User specific confidence levels are only available for 1D option." << std::endl;
+		exit(1);
+	}	
 }
 
 ///


### PR DESCRIPTION
The user can now set up to 4 confidence levels from the command line (as requested in #158).
Not comma separated (might be nicer but I didn't find it possible with the class we use in the OptParser), but similar to the other ``MultiArgs ``, so one could e.g. write `--CL 90 --CL 95` for 90% and 95% confidence levels.
If no user specific confidence level is set, the 1 sigma levels are used. If user specific confidence levels have been set, only these will be calculated.
 
What's missing?
- Plotting: if two guidelines are close, their labels will overlap. that needs a fix
- 2D contours user specific -> forbidden at the moment, but I actually can't think of any use case
- enlarge to infinite number of confidence levels (though 4 might be enough for let's say 99.99% of the cases)

Additionally I moved the output of the switch of interpolation strategies to the debug and verbose mode, as @matthewkenzie requested in #153. 