### PR TITLE
Combiner cls simple and CLs Freq restructuring

### DIFF
--- a/core/include/BatchScriptWriter.h
+++ b/core/include/BatchScriptWriter.h
@@ -11,6 +11,7 @@
 #include "OptParser.h"
 #include "Utils.h"
 #include "Combiner.h"
+#include "PDF_Abs.h"
 
 using namespace std;
 using namespace Utils;
@@ -23,6 +24,7 @@ class BatchScriptWriter
     ~BatchScriptWriter();
 
     void writeScripts(OptParser *arg, vector<Combiner*> *cmb);
+    void writeScripts_datasets(OptParser *arg, PDF_Abs* pdf);
     void writeScript(TString fname, TString outfloc, int jobn, OptParser *arg);
 
     string exec;

--- a/core/include/MethodAbsScan.h
+++ b/core/include/MethodAbsScan.h
@@ -142,7 +142,7 @@ class MethodAbsScan
 		void							calcCLintervalsSimple(int CLsType=0);
 		const std::pair<double, double> getBorders(const TGraph& graph, const double confidence_level, bool qubic=false);
 		const std::pair<double, double> getBorders_CLs(const TGraph& graph, const double confidence_level, bool qubic=false);
-    virtual void                    checkCLs();
+    virtual bool                    checkCLs();
 
 		vector<RooSlimFitResult*> allResults;           ///< All fit results we encounter along the scan.
 		vector<RooSlimFitResult*> curveResults;         ///< All fit results of the the points that make it into the 1-CL curve.

--- a/core/include/ToyTree.h
+++ b/core/include/ToyTree.h
@@ -78,10 +78,12 @@ class ToyTree
 		float chi2minToy;       ///< the chi2 of the fit to the toy with var fixed to scan point
 		float chi2minGlobalToy; ///< the chi2 of the free fit to the toy
 		float chi2minBkgToy;	  ///< the chi2 of the fit of the hypothesis value to the bkg toy distribution (for CLs method)
-    float chi2minGlobalBkgToy; ///< the chi2 of the free fit to the bkg only toys
+    	float chi2minGlobalBkgToy; ///< the chi2 of the free fit to the bkg only toys
+    	float chi2minBkgBkgToy; ///< the chi2 of the bkg fit to the bkg only toys
 		float scanbest;         ///< an alias to the free fit value of the scan variable
 		float scanbesty;        ///< an alias to the free fit value of the scan y variable in 2D scans
-    float scanbestBkg;      ///< an alias to the free fit value of the scan variable on the bkg only toy (for CLs method)
+    	float scanbestBkg;      ///< an alias to the free fit value of the scan variable on the bkg only toy (for CLs method)
+    	float scanbestBkgfitBkg;      ///< an alias to the fit value of the scan variable of the bkg fit on the bkg only toy (for CLs method)
 		float nrun;             ///< an ID to distinguish different runs, i.e. batch jobs
 		float ntoy; 						///< an ID to distinguish different toys
 		float npoint; 				  ///< an ID to distinguish different scan point

--- a/core/src/BatchScriptWriter.cpp
+++ b/core/src/BatchScriptWriter.cpp
@@ -142,7 +142,7 @@ void BatchScriptWriter::writeScripts_datasets(OptParser *arg, PDF_Abs* pdf){
     int month = now->tm_mon+1;
     int year  = now->tm_year+1900;
 
-    TString eos_path = Form("/eos/lhcb/user/t/tmombach/gammacombo/%02d%02d%04d",day,month,year);
+    TString eos_path = Form("/eos/lhcb/user/m/mkenzie/gammacombo/%02d%02d%04d",day,month,year);
     system(Form("/afs/cern.ch/project/eos/installation/0.3.15/bin/eos.select mkdir %s",eos_path.Data()));
     eos_path += Form("/%s",dirname.Data());
     system(Form("/afs/cern.ch/project/eos/installation/0.3.15/bin/eos.select mkdir -p %s",eos_path.Data()));

--- a/core/src/BatchScriptWriter.cpp
+++ b/core/src/BatchScriptWriter.cpp
@@ -70,7 +70,7 @@ void BatchScriptWriter::writeScripts(OptParser *arg, vector<Combiner*> *cmb){
       int month = now->tm_mon+1;
       int year  = now->tm_year+1900;
 
-      TString eos_path = Form("/eos/lhcb/user/m/mkenzie/gammacombo/%02d%02d%04d",day,month,year);
+      TString eos_path = Form("/eos/lhcb/user/t/tmombach/gammacombo/%02d%02d%04d",day,month,year);
       system(Form("/afs/cern.ch/project/eos/installation/0.3.15/bin/eos.select mkdir %s",eos_path.Data()));
       eos_path += Form("/%s",dirname.Data());
       system(Form("/afs/cern.ch/project/eos/installation/0.3.15/bin/eos.select mkdir -p %s",eos_path.Data()));
@@ -90,6 +90,80 @@ void BatchScriptWriter::writeScripts(OptParser *arg, vector<Combiner*> *cmb){
     }
   }
 }
+
+// Copy the same submission script with minor differences for the datasets option
+// -> only difference is that the NLL is stored in the pdf already and does not have to be combined
+// -> no combiners for the datasets option
+void BatchScriptWriter::writeScripts_datasets(OptParser *arg, PDF_Abs* pdf){
+
+  if(!pdf){
+    std::cout<< "BatchScriptWriter::writeScripts_datasets(): ERROR: No PDF given " << std::endl;
+    exit(1);
+  }
+
+  TString methodname = "";
+  if ( arg->isAction("pluginbatch") ) {
+    methodname = "Plugin";
+  }
+  else if ( arg->isAction("coveragebatch") ) {
+    methodname = "Coverage";
+  }
+  else {
+    cout << "BatchScriptWriter::writeScripts() : ERROR : only need to write batch scripts for pluginbatch method" << endl;
+    exit(1);
+  }
+  if ( arg->isAction("uniform") ) methodname += "Uniform";
+  if ( arg->isAction("gaus") ) methodname += "Gaus";
+
+  cout << "Writing submission scripts for PDF " << pdf->getName() << endl;
+
+  TString dirname = "scan1dDatasets"+methodname+"_"+pdf->getName()+"_"+arg->var[0];
+  if ( arg->var.size()==2 ) {
+    dirname = "scan2dDatasets"+methodname+"_"+pdf->getName()+"_"+arg->var[0];
+  }
+  if ( arg->var.size()>1) {
+    dirname += "_"+arg->var[1];
+  }
+  if ( arg->isAction("coveragebatch") ) {
+    dirname += arg->id<0 ? "_id0" : Form("_id%d",arg->id);
+  }
+  TString scripts_dir_path = "sub/" + dirname;
+  TString outf_dir = "root/" + dirname;
+  system(Form("mkdir -p %s",scripts_dir_path.Data()));
+  TString scriptname = "scan1dDatasets"+methodname+"_"+pdf->getName()+"_"+arg->var[0];
+  if ( arg->isAction("coveragebatch") ) {
+    scriptname += arg->id<0 ? "_id0" : Form("_id%d",arg->id) ;
+  }
+  // if write to eos then make the directory
+  if ( arg->batcheos ) {
+    time_t t = time(0);
+    struct tm * now = localtime(&t);
+    int day = now->tm_mday;
+    int month = now->tm_mon+1;
+    int year  = now->tm_year+1900;
+
+    TString eos_path = Form("/eos/lhcb/user/t/tmombach/gammacombo/%02d%02d%04d",day,month,year);
+    system(Form("/afs/cern.ch/project/eos/installation/0.3.15/bin/eos.select mkdir %s",eos_path.Data()));
+    eos_path += Form("/%s",dirname.Data());
+    system(Form("/afs/cern.ch/project/eos/installation/0.3.15/bin/eos.select mkdir -p %s",eos_path.Data()));
+    outf_dir = eos_path;
+  }
+  if ( arg->var.size()==2 ) {
+    scriptname = "scan2dDatasets"+methodname+"_"+pdf->getName()+"_"+arg->var[0];
+  }
+  if ( arg->var.size()>1) {
+    scriptname += "_"+arg->var[1];
+  }
+  scriptname = scripts_dir_path + "/" + scriptname;
+
+  for ( int job=arg->batchstartn; job<arg->batchstartn+arg->nbatchjobs; job++ ) {
+    TString fname = scriptname + Form("_run%d",job) + ".sh";
+    writeScript(fname, outf_dir, job, arg);
+  }
+  // }
+}
+
+
 
 void BatchScriptWriter::writeScript(TString fname, TString outfloc, int jobn, OptParser *arg) {
 

--- a/core/src/GammaComboEngine.cpp
+++ b/core/src/GammaComboEngine.cpp
@@ -2037,7 +2037,18 @@ void GammaComboEngine::scanDataSet()
 		{
 				if ( arg->isAction("pluginbatch") ){
 					MethodDatasetsProbScan* scannerProb = new MethodDatasetsProbScan( (PDF_Datasets*) pdf[0], arg);
-					make1dProbScan( scannerProb, 0 );
+					if ( FileExists( m_fnamebuilder->getFileNameScanner(scannerProb)) ) {
+							scannerProb->initScan();
+							scannerProb->loadScanner( m_fnamebuilder->getFileNameScanner(scannerProb));
+					}
+					else{
+							cout << "\nWARNING : Couldn't load the Prob scanner, will rerun the Prob" << endl;
+							cout <<   "          scan now. You should have run the Prob scan locally" << endl;
+							cout <<   "          before running the Plugin scan." << endl;
+							cout <<   "          missing file: " << m_fnamebuilder->getFileNameScanner(scannerProb) << endl;
+							cout << endl;
+							make1dProbScan(scannerProb, 0);
+					}
 					MethodDatasetsPluginScan *scannerPlugin = new MethodDatasetsPluginScan( scannerProb, (PDF_Datasets*) pdf[0], arg);
 					make1dPluginScan(scannerPlugin, 0 );
 				}

--- a/core/src/GammaComboEngine.cpp
+++ b/core/src/GammaComboEngine.cpp
@@ -1019,10 +1019,21 @@ void GammaComboEngine::defineColors()
   }
 	// catch for datasets
 	if ( arg->combid.size()==0 ) {
+		//sort out fill style
 		if ( arg->fillstyle.size()>0 ) fillStyles.push_back( arg->fillstyle[0] );
 		else fillStyles.push_back(1001);
-    if ( arg->linewidth.size()>0 ) lineWidths.push_back( arg->linewidth[0] );
-    else lineWidths.push_back(2);
+		//sort out fill color
+		if ( arg->fillcolor.size()>0 ) fillColors.push_back( arg->fillcolor[0] );
+		else fillColors.push_back(colorsLine[0]);
+		//sort out line width
+    	if ( arg->linewidth.size()>0 ) lineWidths.push_back( arg->linewidth[0] );
+    	else lineWidths.push_back(2);
+    	//sort out line style
+    	if ( arg->linestyle.size()>0 ) lineStyles.push_back( arg->linestyle[0] );
+    	else lineStyles.push_back(1);
+    	//sort out line color
+    	if ( arg->linecolor.size()>0 ) lineColors.push_back( arg->linecolor[0] );
+    	else lineColors.push_back(colorsLine[0]);
 	}
 }
 
@@ -1241,22 +1252,22 @@ void GammaComboEngine::make1dCoverageScan(MethodCoverageScan *scanner, int cId)
 void GammaComboEngine::make1dProbPlot(MethodProbScan *scanner, int cId)
 {
 
-  if (!arg->isAction("pluginbatch") && !arg->plotpluginonly){
+  	if (!arg->isAction("pluginbatch") && !arg->plotpluginonly){
 		scanner->setDrawSolution(arg->plotsolutions[cId]);
-    if ( arg->cls.size()>0 ) {
-      if ( runOnDataSet ) ((MethodDatasetsProbScan*)scanner)->plotFitRes(m_fnamebuilder->getFileNamePlot(cmb)+"_fit");
-      scanner->plotOn(plot, 1); // for prob ClsType>1 doesn't exist
-    }
+    	if ( arg->cls.size()>0 ) {
+      		if ( runOnDataSet ) ((MethodDatasetsProbScan*)scanner)->plotFitRes(m_fnamebuilder->getFileNamePlot(cmb)+"_fit");
+      		scanner->plotOn(plot, 1); // for prob ClsType>1 doesn't exist
+    	}
 		scanner->plotOn(plot);
 		int colorId = cId;
 		if ( arg->color.size()>cId ) colorId = arg->color[cId];
 		//scanner->setLineColor(colorsLine[colorId]);
 		scanner->setTextColor(colorsText[colorId]);
-    scanner->setLineColor(lineColors[cId]);
-    scanner->setLineStyle(lineStyles[cId]);
-    scanner->setLineWidth(lineWidths[cId]);
-    scanner->setFillColor(fillColors[cId]);
-    scanner->setFillStyle(fillStyles[cId]);
+    	scanner->setLineColor(lineColors[cId]);
+    	scanner->setLineStyle(lineStyles[cId]);
+    	scanner->setLineWidth(lineWidths[cId]);
+    	scanner->setFillColor(fillColors[cId]);
+    	scanner->setFillStyle(fillStyles[cId]);
 		plot->Draw();
 	}
 }

--- a/core/src/GammaComboEngine.cpp
+++ b/core/src/GammaComboEngine.cpp
@@ -1676,8 +1676,13 @@ void GammaComboEngine::setObservablesFromFile(Combiner *c, int cId)
 ///
 void GammaComboEngine::writebatchscripts()
 {
-  m_batchscriptwriter->writeScripts(arg, &cmb);
-  exit(0);
+	if (runOnDataSet){
+		m_batchscriptwriter->writeScripts_datasets(arg, getPdf(0));
+	}
+	else{
+		m_batchscriptwriter->writeScripts(arg, &cmb);
+	}
+  	exit(0);
 }
 
 ///

--- a/core/src/MethodAbsScan.cpp
+++ b/core/src/MethodAbsScan.cpp
@@ -244,6 +244,11 @@ void MethodAbsScan::initScan()
 	hCL = new TH1F("hCL"+getUniqueRootName(), "hCL"+pdfName, nPoints1d, min1, max1);
 	if ( hChi2min ) delete hChi2min;
 	hChi2min = new TH1F("hChi2min"+getUniqueRootName(), "hChi2min"+pdfName, nPoints1d, min1, max1);
+    if (hCLs) delete hCLs;
+    hCLs = new TH1F("hCLs" + getUniqueRootName(), "hCLs" + pdfName, nPoints1d, min1, max1);
+    if (hCLs) delete hCLsFreq;
+    hCLsFreq = new TH1F("hCLsFreq" + getUniqueRootName(), "hCLsFreq" + pdfName, nPoints1d, min1, max1);
+
 
 	// fill the chi2 histogram with very unlikely values such
 	// that inside scan1d() the if clauses work correctly
@@ -1615,8 +1620,14 @@ const std::pair<double, double> MethodAbsScan::getBorders_CLs(const TGraph& grap
   return std::pair<double, double>(lower_edge,upper_edge);
 }
 
-void MethodAbsScan::checkCLs()
+bool MethodAbsScan::checkCLs()
 {
+	if (!hCLsExp || !hCLsErr1Up || !hCLsErr1Dn || !hCLsErr2Up || !hCLsErr2Dn){
+		std::cout << "ERROR: ***************************************************" << std::endl;
+		std::cout << "ERROR: MethodAbsScan::checkCLs() : No CLs plot available!!" << std::endl;
+		std::cout << "ERROR: ***************************************************" << std::endl;
+		return false;
+	}
   assert( hCLsExp->GetNbinsX() == hCLsErr1Up->GetNbinsX() );
   assert( hCLsExp->GetNbinsX() == hCLsErr2Up->GetNbinsX() );
   assert( hCLsExp->GetNbinsX() == hCLsErr1Dn->GetNbinsX() );
@@ -1640,6 +1651,7 @@ void MethodAbsScan::checkCLs()
       hCLsErr2Dn->SetBinContent(i, hCLsExp->GetBinContent(i) - ( hCLsExp->GetBinContent(i)-hCLsErr1Dn->GetBinContent(i))*2. );
     }
   }
+  return true;
 }
 
 

--- a/core/src/MethodDatasetsPluginScan.cpp
+++ b/core/src/MethodDatasetsPluginScan.cpp
@@ -451,12 +451,12 @@ void MethodDatasetsPluginScan::readScan1dTrees(int runMin, int runMax, TString f
         // sbTestStatVal = t.scanbest <= t.scanpoint ? sbTestStatVal : 0.; // if muhat < mu then q_mu = 0
         // sampledSBValues[hBin].push_back( sbTestStatVal );
 
-        // chi2minBkgToy is the best fit at scanpoint of bkg-only toy, chi2minGlobalBkgToy is the best global fit of the bkg-only toy
+        // chi2minBkgBkgToy is the best fit of the bkg pdf of bkg-only toy, chi2minGlobalBkgToy is the best global fit of the bkg-only toy
         double bkgTestStatVal = t.chi2minBkgBkgToy - t.chi2minGlobalBkgToy;
-        std::cout << bkgTestStatVal << ": " << t.chi2minBkgBkgToy << " - " << t.chi2minGlobalBkgToy << std::endl;
         if(bkgTestStatVal < 0.) bkgTestStatVal = 0.;
         bkgTestStatVal = t.scanbestBkgfitBkg <= t.scanpoint ? bkgTestStatVal : 0.;  // if muhat < mu then q_mu = 0
         sampledBValues[hBin].push_back( bkgTestStatVal );
+        // chi2minBkgToy is the best fit at scanpoint of bkg-only toy, chi2minGlobalBkgToy is the best global fit of the bkg-only toy
         double sbTestStatVal = t.chi2minBkgToy - t.chi2minGlobalBkgToy;
         sbTestStatVal = t.scanbestBkg <= t.scanpoint ? sbTestStatVal : 0.; // if muhat < mu then q_mu = 0
         sampledSBValues[hBin].push_back( sbTestStatVal );
@@ -552,12 +552,6 @@ void MethodDatasetsPluginScan::readScan1dTrees(int runMin, int runMax, TString f
         // hCLsErr2Up->SetBinContent( i, TMath::Min( clsb_vals[0] / clb_vals[0] , 1.) );
         // hCLsErr2Dn->SetBinContent( i, TMath::Min( clsb_vals[4] / clb_vals[4] , 1.) );
 
-        //// Titus wrongly transformed
-        // hCLsExp->SetBinContent   ( i, TMath::Min( clsb_vals[2] , 1.) );
-        // hCLsErr1Up->SetBinContent( i, TMath::Min( clsb_vals[1] , 1.) );
-        // hCLsErr1Dn->SetBinContent( i, TMath::Min( clsb_vals[3] , 1.) );
-        // hCLsErr2Up->SetBinContent( i, TMath::Min( clsb_vals[0] , 1.) );
-        // hCLsErr2Dn->SetBinContent( i, TMath::Min( clsb_vals[4] , 1.) );
         hCLsExp->SetBinContent   ( i, TMath::Min( clsb_vals[2] , 1.) );
         hCLsErr1Up->SetBinContent( i, TMath::Min( clsb_vals[3] , 1.) );
         hCLsErr1Dn->SetBinContent( i, TMath::Min( clsb_vals[1] , 1.) );

--- a/core/src/MethodDatasetsPluginScan.cpp
+++ b/core/src/MethodDatasetsPluginScan.cpp
@@ -523,11 +523,16 @@ void MethodDatasetsPluginScan::readScan1dTrees(int runMin, int runMax, TString f
           cout << endl;
         }
 
-        hCLsExp->SetBinContent   ( i, TMath::Min( clsb_vals[2] / clb_vals[2] , 1.) );
-        hCLsErr1Up->SetBinContent( i, TMath::Min( clsb_vals[1] / clb_vals[1] , 1.) );
-        hCLsErr1Dn->SetBinContent( i, TMath::Min( clsb_vals[3] / clb_vals[3] , 1.) );
-        hCLsErr2Up->SetBinContent( i, TMath::Min( clsb_vals[0] / clb_vals[0] , 1.) );
-        hCLsErr2Dn->SetBinContent( i, TMath::Min( clsb_vals[4] / clb_vals[4] , 1.) );
+        // hCLsExp->SetBinContent   ( i, TMath::Min( clsb_vals[2] / clb_vals[2] , 1.) );
+        // hCLsErr1Up->SetBinContent( i, TMath::Min( clsb_vals[1] / clb_vals[1] , 1.) );
+        // hCLsErr1Dn->SetBinContent( i, TMath::Min( clsb_vals[3] / clb_vals[3] , 1.) );
+        // hCLsErr2Up->SetBinContent( i, TMath::Min( clsb_vals[0] / clb_vals[0] , 1.) );
+        // hCLsErr2Dn->SetBinContent( i, TMath::Min( clsb_vals[4] / clb_vals[4] , 1.) );
+        hCLsExp->SetBinContent   ( i, TMath::Min( clsb_vals[2] , 1.) );
+        hCLsErr1Up->SetBinContent( i, TMath::Min( clsb_vals[1] , 1.) );
+        hCLsErr1Dn->SetBinContent( i, TMath::Min( clsb_vals[3] , 1.) );
+        hCLsErr2Up->SetBinContent( i, TMath::Min( clsb_vals[0] , 1.) );
+        hCLsErr2Dn->SetBinContent( i, TMath::Min( clsb_vals[4] , 1.) );
 
         //hCLsExp->SetBinContent   ( i, (float(nSBValsAboveBkg[2]) / sampledSBValues[i].size() ) / probs[2] );
         //hCLsErr1Up->SetBinContent( i, (float(nSBValsAboveBkg[1]) / sampledSBValues[i].size() ) / probs[1] );

--- a/core/src/MethodDatasetsPluginScan.cpp
+++ b/core/src/MethodDatasetsPluginScan.cpp
@@ -348,6 +348,8 @@ void MethodDatasetsPluginScan::readScan1dTrees(int runMin, int runMax, TString f
     TH1F *h_better        = (TH1F*)hCL->Clone("h_better");
     // histogram to store number of toys which enter CLs p Value calculation
     TH1F *h_better_cls        = (TH1F*)hCL->Clone("h_better_cls");
+    // histogram to store number of toys which enter CLb p Value calculation
+    TH1F *h_better_clb        = (TH1F*)hCL->Clone("h_better_clb");
     // numbers for all toys
     TH1F *h_all           = (TH1F*)hCL->Clone("h_all");
     // numbers of toys failing the selection criteria
@@ -418,6 +420,9 @@ void MethodDatasetsPluginScan::readScan1dTrees(int runMin, int runMax, TString f
         if ( valid && (t.chi2minToy - t.chi2minGlobalToy) >= (t.chi2min - this->chi2minBkg) ) { //t.chi2minGlobal ){
             h_better_cls->Fill(t.scanpoint);
         }
+        if ( valid && (t.chi2minBkgBkgToy - t.chi2minGlobalBkgToy) >= (chi2minBkg - chi2minGlobal) ) {
+            h_better_clb->Fill(t.scanpoint);
+        }
         if (t.scanpoint == 0.0) n0better++;
 
         // goodness-of-fit
@@ -435,12 +440,28 @@ void MethodDatasetsPluginScan::readScan1dTrees(int runMin, int runMax, TString f
         int hBin = h_all->FindBin(t.scanpoint);
         if ( sampledBValues.find(hBin) == sampledBValues.end() ) sampledBValues[hBin] = std::vector<double>();
         if ( sampledSBValues.find(hBin) == sampledSBValues.end() ) sampledSBValues[hBin] = std::vector<double>();
-        double bkgTestStatVal = t.chi2minBkgToy - t.chi2minGlobalBkgToy;
-        bkgTestStatVal = t.scanbestBkg <= t.scanpoint ? bkgTestStatVal : 0.;  // if muhat < mu then q_mu = 0
+
+        ////// comment Matt's part for the moment
+        // // chi2minBkgToy is the best fit at scanpoint of bkg-only toy, chi2minGlobalBkgToy is the best global fit of the bkg-only toy
+        // double bkgTestStatVal = t.chi2minBkgToy - t.chi2minGlobalBkgToy;
+        // std::cout << bkgTestStatVal << ": " << t.chi2minBkgToy << " - " << t.chi2minGlobalBkgToy << std::endl;
+        // bkgTestStatVal = t.scanbestBkg <= t.scanpoint ? bkgTestStatVal : 0.;  // if muhat < mu then q_mu = 0
+        // sampledBValues[hBin].push_back( bkgTestStatVal );
+        // double sbTestStatVal = t.chi2minToy - t.chi2minGlobalToy;
+        // sbTestStatVal = t.scanbest <= t.scanpoint ? sbTestStatVal : 0.; // if muhat < mu then q_mu = 0
+        // sampledSBValues[hBin].push_back( sbTestStatVal );
+
+        // chi2minBkgToy is the best fit at scanpoint of bkg-only toy, chi2minGlobalBkgToy is the best global fit of the bkg-only toy
+        double bkgTestStatVal = t.chi2minBkgBkgToy - t.chi2minGlobalBkgToy;
+        std::cout << bkgTestStatVal << ": " << t.chi2minBkgBkgToy << " - " << t.chi2minGlobalBkgToy << std::endl;
+        if(bkgTestStatVal < 0.) bkgTestStatVal = 0.;
+        bkgTestStatVal = t.scanbestBkgfitBkg <= t.scanpoint ? bkgTestStatVal : 0.;  // if muhat < mu then q_mu = 0
         sampledBValues[hBin].push_back( bkgTestStatVal );
-        double sbTestStatVal = t.chi2minToy - t.chi2minGlobalToy;
-        sbTestStatVal = t.scanbest <= t.scanpoint ? sbTestStatVal : 0.; // if muhat < mu then q_mu = 0
+        double sbTestStatVal = t.chi2minBkgToy - t.chi2minGlobalBkgToy;
+        sbTestStatVal = t.scanbestBkg <= t.scanpoint ? sbTestStatVal : 0.; // if muhat < mu then q_mu = 0
         sampledSBValues[hBin].push_back( sbTestStatVal );
+
+
 
         // use the unphysical events to estimate background (be careful with this,
         // at least inspect the control plots to judge if this can be at all reasonable)
@@ -469,6 +490,7 @@ void MethodDatasetsPluginScan::readScan1dTrees(int runMin, int runMax, TString f
     for (int i = 1; i <= h_better->GetNbinsX(); i++) {
         float nbetter = h_better->GetBinContent(i);
         float nbetter_cls = h_better_cls->GetBinContent(i);
+        float nbetter_clb = h_better_clb->GetBinContent(i);
         float nall = h_all->GetBinContent(i);
         // get number of background and failed toys
         float nbackground     = h_background->GetBinContent(i);
@@ -488,6 +510,7 @@ void MethodDatasetsPluginScan::readScan1dTrees(int runMin, int runMax, TString f
         // don't subtract background
         float p = nbetter / nall;
         float p_cls = nbetter_cls / nall;
+        float p_clb = nbetter_clb / nall;
         hCL->SetBinContent(i, p);
         hCL->SetBinError(i, sqrt(p * (1. - p) / nall));
         hCLs->SetBinContent(i, p_cls);
@@ -503,7 +526,7 @@ void MethodDatasetsPluginScan::readScan1dTrees(int runMin, int runMax, TString f
           // asymptotic as chi2
           //clsb_vals.push_back( TMath::Prob( quantiles[k], 1 ) );
           // from toys
-          clsb_vals.push_back( getVectorFracAboveValue( sampledSBValues[i], quantiles[k] ) );
+          clsb_vals.push_back(1.-getVectorFracAboveValue( sampledSBValues[i], quantiles[k] ) );
         }
 
         // check
@@ -522,17 +545,24 @@ void MethodDatasetsPluginScan::readScan1dTrees(int runMin, int runMax, TString f
           for (int k=0; k<clsb_vals.size(); k++) cout << clsb_vals[k]/clb_vals[k] << " , ";
           cout << endl;
         }
-
+        //// Matt's idea
         // hCLsExp->SetBinContent   ( i, TMath::Min( clsb_vals[2] / clb_vals[2] , 1.) );
         // hCLsErr1Up->SetBinContent( i, TMath::Min( clsb_vals[1] / clb_vals[1] , 1.) );
         // hCLsErr1Dn->SetBinContent( i, TMath::Min( clsb_vals[3] / clb_vals[3] , 1.) );
         // hCLsErr2Up->SetBinContent( i, TMath::Min( clsb_vals[0] / clb_vals[0] , 1.) );
         // hCLsErr2Dn->SetBinContent( i, TMath::Min( clsb_vals[4] / clb_vals[4] , 1.) );
+
+        //// Titus wrongly transformed
+        // hCLsExp->SetBinContent   ( i, TMath::Min( clsb_vals[2] , 1.) );
+        // hCLsErr1Up->SetBinContent( i, TMath::Min( clsb_vals[1] , 1.) );
+        // hCLsErr1Dn->SetBinContent( i, TMath::Min( clsb_vals[3] , 1.) );
+        // hCLsErr2Up->SetBinContent( i, TMath::Min( clsb_vals[0] , 1.) );
+        // hCLsErr2Dn->SetBinContent( i, TMath::Min( clsb_vals[4] , 1.) );
         hCLsExp->SetBinContent   ( i, TMath::Min( clsb_vals[2] , 1.) );
-        hCLsErr1Up->SetBinContent( i, TMath::Min( clsb_vals[1] , 1.) );
-        hCLsErr1Dn->SetBinContent( i, TMath::Min( clsb_vals[3] , 1.) );
-        hCLsErr2Up->SetBinContent( i, TMath::Min( clsb_vals[0] , 1.) );
-        hCLsErr2Dn->SetBinContent( i, TMath::Min( clsb_vals[4] , 1.) );
+        hCLsErr1Up->SetBinContent( i, TMath::Min( clsb_vals[3] , 1.) );
+        hCLsErr1Dn->SetBinContent( i, TMath::Min( clsb_vals[1] , 1.) );
+        hCLsErr2Up->SetBinContent( i, TMath::Min( clsb_vals[4] , 1.) );
+        hCLsErr2Dn->SetBinContent( i, TMath::Min( clsb_vals[0] , 1.) );
 
         //hCLsExp->SetBinContent   ( i, (float(nSBValsAboveBkg[2]) / sampledSBValues[i].size() ) / probs[2] );
         //hCLsErr1Up->SetBinContent( i, (float(nSBValsAboveBkg[1]) / sampledSBValues[i].size() ) / probs[1] );
@@ -546,7 +576,8 @@ void MethodDatasetsPluginScan::readScan1dTrees(int runMin, int runMax, TString f
         for (int j=0; j<sampledBValues[i].size(); j++ ) {
           if ( sampledBValues[i][j] >= dataTestStat ) nDataAboveBkgExp += 1;
         }
-        float dataCLb    = float(nDataAboveBkgExp)/sampledBValues[i].size();
+        // float dataCLb    = float(nDataAboveBkgExp)/sampledBValues[i].size();
+        float dataCLb    = p_clb;
         float dataCLbErr = sqrt( dataCLb * (1.-dataCLb) / sampledBValues[i].size() );
         if ( p/dataCLb >= 1. ) {
           hCLsFreq->SetBinContent(i, 1.);
@@ -692,9 +723,11 @@ int MethodDatasetsPluginScan::scan1d(int nRun)
 		// if CLs toys we need to keep hold of what's going on in the bkg only case
     // there is a small overhead here but it's necessary because the bkg only hypothesis
     // might not necessarily be in the scan range (although often it will be the first point)
-		vector<RooDataSet*> cls_bkgOnlyToys;
-    vector<float> chi2minGlobalBkgToysStore;
-    vector<float> scanbestBkgToysStore;
+	vector<RooDataSet*> cls_bkgOnlyToys;
+    vector<float> chi2minGlobalBkgToysStore;    // Global fit to bkg-only toys
+    vector<float> chi2minBkgBkgToysStore;       // Bkg fit to bkg-only toys
+    vector<float> scanbestBkgToysStore;         // best fit point of gloabl fit to bkg-only toys 
+    vector<float> scanbestBkgBkgToysStore;      // best fit point of bkg fit to bkg-only toys (usually zero because bkg pdf will not depend on signal parameter)
     // Titus: Try importance sampling from the combination part -> works, but definitely needs improvement in precision
     int nActualToys = nToys;
     if ( arg->importance ){
@@ -703,19 +736,24 @@ int MethodDatasetsPluginScan::scan1d(int nRun)
     }
     for ( int j = 0; j < nActualToys; j++ ) {
       if(pdf->getBkgPdf()){
+        pdf->fitBkg(pdf->getData());     //Need to fit bkg first to get the proper parameters for the toy generation
         pdf->generateBkgToys();
         pdf->generateToysGlobalObservables();
         RooDataSet* bkgOnlyToy = pdf->getBkgToyObservables();
         cls_bkgOnlyToys.push_back( (RooDataSet*)bkgOnlyToy->Clone() ); // clone required because of deleteToys() call at end of loop
         pdf->setToyData( bkgOnlyToy );
         parameterToScan->setConstant(false);
+
+        // Do a global fit to bkg-only toys
         RooFitResult *rb = loadAndFit(pdf);
+        // RooFitResult *rb = pdf->fitBkg(bkgOnlyToy);
         assert(rb);
         pdf->setMinNllScan(pdf->minNll);
         if (pdf->getFitStatus() != 0) {
             pdf->setFitStrategy(1);
             delete rb;
             rb = loadAndFit(pdf);
+            // rb = pdf->fitBkg(bkgOnlyToy);
             pdf->setMinNllScan(pdf->minNll);
             assert(rb);
 
@@ -723,6 +761,7 @@ int MethodDatasetsPluginScan::scan1d(int nRun)
                 pdf->setFitStrategy(2);
                 delete rb;
                 rb = loadAndFit(pdf);
+                // rb = pdf->fitBkg(bkgOnlyToy);
                 assert(rb);
             }
         }
@@ -735,9 +774,39 @@ int MethodDatasetsPluginScan::scan1d(int nRun)
         }
         pdf->setMinNllScan(pdf->minNll);
 
-        chi2minGlobalBkgToysStore.push_back( 2 * rb->minNll() );
-        scanbestBkgToysStore.push_back( ((RooRealVar*)w->set(pdf->getParName())->find(scanVar1))->getVal() );
+        // chi2minGlobalBkgToysStore.push_back( 2 * rb->minNll() );
+        chi2minGlobalBkgToysStore.push_back( 2 * pdf->getMinNll() );
+        if(rb->floatParsFinal().find(pdf->getParName())){
+            scanbestBkgToysStore.push_back( ((RooRealVar*)w->set(pdf->getParName())->find(scanVar1))->getVal() );    
+        }
+        // if the pdf does not depend on the signal parameter, set best fit value of signa l parameter for the bkg fit to 0
+        else scanbestBkgToysStore.push_back(0.0);
 
+        delete rb;
+        rb = pdf->fitBkg(bkgOnlyToy);
+        assert(rb);
+        pdf->setMinNllScan(pdf->minNll);
+        if (pdf->getFitStatus() != 0) {
+            pdf->setFitStrategy(1);
+            delete rb;
+            rb = pdf->fitBkg(bkgOnlyToy);
+            pdf->setMinNllScan(pdf->minNll);
+            assert(rb);
+
+            if (pdf->getFitStatus() != 0) {
+                pdf->setFitStrategy(2);
+                delete rb;
+                rb = pdf->fitBkg(bkgOnlyToy);
+                assert(rb);
+            }
+        }
+        // chi2minBkgBkgToysStore.push_back( 2 * rb->minNll() );
+        chi2minBkgBkgToysStore.push_back( 2 * pdf->getMinNllBkg() );
+        if(rb->floatParsFinal().find(pdf->getParName())){
+            scanbestBkgBkgToysStore.push_back( ((RooRealVar*)w->set(pdf->getParName())->find(scanVar1))->getVal() );    
+        }
+        // if the pdf does not depend on the signal parameter, set best fit value of signa l parameter for the bkg fit to 0
+        else scanbestBkgBkgToysStore.push_back(0.0);
         delete rb;
         pdf->deleteToys();
       }
@@ -882,7 +951,8 @@ int MethodDatasetsPluginScan::scan1d(int nRun)
             pdf->setMinNllScan(pdf->minNll);
 
 
-            toyTree.chi2minToy          = 2 * r->minNll(); // 2*r->minNll(); //2*r->minNll();
+            // toyTree.chi2minToy          = 2 * r->minNll(); // 2*r->minNll(); //2*r->minNll();
+            toyTree.chi2minToy          = 2 * pdf->getMinNll(); // 2*r->minNll(); //2*r->minNll();
             toyTree.chi2minToyPDF       = 2 * pdf->getMinNllScan();
             toyTree.covQualScan         = r->covQual();
             toyTree.statusScan          = r->status();
@@ -943,7 +1013,8 @@ int MethodDatasetsPluginScan::scan1d(int nRun)
             pdf->setMinNllScan(pdf->minNll);
 
 
-            toyTree.chi2minBkgToy          = 2 * rb->minNll(); // 2*r->minNll(); //2*r->minNll();
+            // toyTree.chi2minBkgToy          = 2 * rb->minNll(); // 2*r->minNll(); //2*r->minNll();
+            toyTree.chi2minBkgToy          = 2 * pdf->getMinNll(); // 2*r->minNll(); //2*r->minNll();
             toyTree.chi2minBkgToyPDF       = 2 * pdf->getMinNllScan();
 
             pdf->deleteNLL();
@@ -970,7 +1041,8 @@ int MethodDatasetsPluginScan::scan1d(int nRun)
             RooFitResult* r1  = this->loadAndFit(this->pdf);
             assert(r1);
             pdf->setMinNllFree(pdf->minNll);
-            toyTree.chi2minGlobalToy = 2 * r1->minNll();
+            // toyTree.chi2minGlobalToy = 2 * r1->minNll();
+            toyTree.chi2minGlobalToy = 2 * pdf->getMinNllFree();
 
             if (! std::isfinite(pdf->getMinNllFree())) {
                 cout << "----> nan/inf flag detected " << endl;
@@ -992,7 +1064,8 @@ int MethodDatasetsPluginScan::scan1d(int nRun)
                 r1  = this->loadAndFit(this->pdf);
                 assert(r1);
                 pdf->setMinNllFree(pdf->minNll);
-                toyTree.chi2minGlobalToy = 2 * r1->minNll();
+                // toyTree.chi2minGlobalToy = 2 * r1->minNll();
+                toyTree.chi2minGlobalToy = 2 * pdf->getMinNllFree();
                 if (! std::isfinite(pdf->getMinNllFree())) {
                     cout << "----> nan/inf flag detected " << endl;
                     cout << "----> fit status: " << pdf->getFitStatus() << endl;
@@ -1011,7 +1084,8 @@ int MethodDatasetsPluginScan::scan1d(int nRun)
                     r1  = this->loadAndFit(this->pdf);
                     assert(r1);
                     pdf->setMinNllFree(pdf->minNll);
-                    toyTree.chi2minGlobalToy = 2 * r1->minNll();
+                    // toyTree.chi2minGlobalToy = 2 * r1->minNll();
+                    toyTree.chi2minGlobalToy = 2 * pdf->getMinNllFree();
                     if (! std::isfinite(pdf->getMinNllFree())) {
                         cout << "----> nan/inf flag detected " << endl;
                         cout << "----> fit status: " << pdf->getFitStatus() << endl;
@@ -1058,7 +1132,8 @@ int MethodDatasetsPluginScan::scan1d(int nRun)
             // set the limit back again
             setLimit(w, scanVar1, "scan");
 
-            toyTree.chi2minGlobalToy    = 2 * r1->minNll(); //2*r1->minNll();
+            // toyTree.chi2minGlobalToy    = 2 * r1->minNll(); //2*r1->minNll();
+            toyTree.chi2minGlobalToy    = 2 * pdf->getMinNllFree(); //2*r1->minNll();
             toyTree.chi2minGlobalToyPDF = 2 * pdf->getMinNllFree(); //2*r1->minNll();
             toyTree.statusFreePDF       = pdf->getFitStatus(); //r1->status();
             toyTree.statusFree          = r1->status();
@@ -1073,11 +1148,15 @@ int MethodDatasetsPluginScan::scan1d(int nRun)
               //scanbestBkgToysStore.push_back( toyTree.scanbest );
             //}
             //else {
-              assert( chi2minGlobalBkgToysStore.size() == nToys );
-              assert( scanbestBkgToysStore.size() == nToys );
-              //}
+            assert( chi2minGlobalBkgToysStore.size() == nToys );
+            assert( scanbestBkgToysStore.size() == nToys );
+            assert( chi2minBkgBkgToysStore.size() == nToys );
+            assert( scanbestBkgBkgToysStore.size() == nToys );
+            //}
             toyTree.chi2minGlobalBkgToy = chi2minGlobalBkgToysStore[j];
             toyTree.scanbestBkg      = scanbestBkgToysStore[j];
+            toyTree.chi2minBkgBkgToy = chi2minBkgBkgToysStore[j];
+            toyTree.scanbestBkgfitBkg      = scanbestBkgBkgToysStore[j];
 
             if (arg->debug) {
                 cout << "#### > Fit summary: " << endl;

--- a/core/src/MethodDatasetsPluginScan.cpp
+++ b/core/src/MethodDatasetsPluginScan.cpp
@@ -827,8 +827,8 @@ int MethodDatasetsPluginScan::scan1d(int nRun)
         toyTree.scanpoint = scanpoint;
 
 				if ( i==0 && scanpoint != 0 ) {
-					cout << "ERROR: For CLs option the first point in the scan must be zero not: " << scanpoint << endl;
-					exit(1);
+					cout << "WARNING: For CLs option the first point in the scan should be zero, not: " << scanpoint << endl;
+					// exit(1);
 				}
 
         if (arg->debug) cout << "DEBUG in MethodDatasetsPluginScan::scan1d_plugin() - scanpoint in step " << i << " : " << scanpoint << endl;

--- a/core/src/MethodDatasetsPluginScan.cpp
+++ b/core/src/MethodDatasetsPluginScan.cpp
@@ -474,8 +474,9 @@ void MethodDatasetsPluginScan::readScan1dTrees(int runMin, int runMax, TString f
         double bkgTestStatVal = t.chi2minBkgBkgToy - t.chi2minGlobalBkgToy;
         
         if( !BadBkgFit ){
-            bkg_pvals->Fill(TMath::Prob(bkgTestStatVal,1));
-
+            if(hBin==1){
+                bkg_pvals->Fill(TMath::Prob(bkgTestStatVal,1));
+            }
             // bkgTestStatVal = t.scanbestBkgfitBkg <= t.scanpoint ? bkgTestStatVal : 0.;  // if muhat < mu then q_mu = 0
             sampledBValues[hBin].push_back( bkgTestStatVal );
             // chi2minBkgToy is the best fit at scanpoint of bkg-only toy, chi2minGlobalBkgToy is the best global fit of the bkg-only toy
@@ -560,11 +561,6 @@ void MethodDatasetsPluginScan::readScan1dTrees(int runMin, int runMax, TString f
         // check
         if ( arg->debug ) {
           cout << i << endl;
-          if(i==1){
-            for(auto bchi2 : sampledBValues[i]){
-                std::cout << bchi2 << std::endl;
-            }
-          }
           cout << "Quants: ";
           for (int k=0; k<quantiles.size(); k++) cout << quantiles[k] << " , ";
           cout << endl;
@@ -635,8 +631,10 @@ void MethodDatasetsPluginScan::readScan1dTrees(int runMin, int runMax, TString f
 
     if (arg->debug || drawPlots) {
         TCanvas *canvas1 = new TCanvas("canvas1", "canvas1", 1200, 1000);
+        bkg_pvals->SetLineWidth(2);
+        bkg_pvals->SetXTitle("bkg-only p value");
         bkg_pvals->Draw();
-        canvas1->SaveAs("bkg_only_pvalues.pdf");
+        savePlot(canvas1,"bkg_only_pvalues");
         TCanvas* can = new TCanvas("can", "can", 1024, 786);
         can->cd();
         gStyle->SetOptTitle(0);

--- a/core/src/MethodPluginScan.cpp
+++ b/core/src/MethodPluginScan.cpp
@@ -824,6 +824,22 @@ TH1F* MethodPluginScan::analyseToys(ToyTree* t, int id)
 	Long64_t nwrongrun = 0;
 	Long64_t ntoysid   = 0; // if id is not -1, this will count the number of toys with that id
 
+	delete hCLsExp;
+    hCLsExp = new TH1F("hCLsExp", "hCLs", t->getScanpointN(), t->getScanpointMin() - halfBinWidth, t->getScanpointMax() + halfBinWidth);
+    delete hCLsErr1Up;
+    hCLsErr1Up = new TH1F("hCLsErr1Up", "hCLs", t->getScanpointN(), t->getScanpointMin() - halfBinWidth, t->getScanpointMax() + halfBinWidth);
+    delete hCLsErr1Dn;
+    hCLsErr1Dn = new TH1F("hCLsErr1Dn", "hCLs", t->getScanpointN(), t->getScanpointMin() - halfBinWidth, t->getScanpointMax() + halfBinWidth);
+    delete hCLsErr2Up;
+    hCLsErr2Up = new TH1F("hCLsErr2Up", "hCLs", t->getScanpointN(), t->getScanpointMin() - halfBinWidth, t->getScanpointMax() + halfBinWidth);
+    delete hCLsErr2Dn;
+    hCLsErr2Dn = new TH1F("hCLsErr2Dn", "hCLs", t->getScanpointN(), t->getScanpointMin() - halfBinWidth, t->getScanpointMax() + halfBinWidth);
+
+    // map of vectors for CLb quantiles
+    std::map<int,std::vector<double> > sampledBValues;
+    std::map<int,std::vector<double> > sampledSBValues;
+
+
 	t->activateCoreBranchesOnly(); // speeds up the event loop
 	ProgressBar pb(arg, nentries);
 	if ( arg->debug ) cout << "MethodPluginScan::analyseToys() : ";
@@ -886,6 +902,17 @@ TH1F* MethodPluginScan::analyseToys(ToyTree* t, int id)
 		if ( !inPhysicalRegion ){
 			h_background->Fill(t->scanpoint);
 		}
+
+		// sample the distribution of the background test statistic as the test statistic in the lowest bin
+		int hBin = h_all->FindBin(t->scanpoint);
+		if (t->scanpoint==t->getScanpointMin()){
+        	double bkgTestStatVal = t->chi2minToy - t->chi2minGlobalToy;
+        	bkgTestStatVal = t->scanbest <= t->scanpoint ? bkgTestStatVal : 0.;  // if muhat < mu then q_mu = 0
+        	sampledBValues[hBin].push_back( bkgTestStatVal );
+    	}
+        double sbTestStatVal = t->chi2minToy - t->chi2minGlobalToy;
+        sbTestStatVal = t->scanbest <= t->scanpoint ? sbTestStatVal : 0.; // if muhat < mu then q_mu = 0
+        sampledSBValues[hBin].push_back( sbTestStatVal );		
 	}
 
 	if ( arg->debug ) cout << "MethodPluginScan::analyseToys() : ";
@@ -926,6 +953,51 @@ TH1F* MethodPluginScan::analyseToys(ToyTree* t, int id)
 		}
 		hCL->SetBinContent(i, p);
 		hCL->SetBinError(i, sqrt(p * (1.-p)/nall));
+		float p_bkg = TMath::Min(p/hCL->GetBinContent(1), 1.);
+		hCLsFreq->SetBinContent(i, p_bkg);
+		hCLsFreq->SetBinError(i, sqrt(p_bkg * (1.-p_bkg)/nall));
+
+		        // the quantiles of the CLb distribution (for expected CLs)
+        std::vector<double> probs  = { TMath::Prob(4,1), TMath::Prob(1,1), 0.5, 1.-TMath::Prob(1,1), 1.-TMath::Prob(4,1) };
+        std::vector<double> clb_vals  = { 1.-TMath::Prob(4,1), 1.-TMath::Prob(1,1), 0.5, TMath::Prob(1,1), TMath::Prob(4,1) };
+        std::vector<double> quantiles = Quantile<double>( sampledBValues[i], probs );
+        std::vector<double> clsb_vals;
+        //for (int k=0; k<quantiles.size(); k++) clsb_vals.push_back( TMath::Prob( quantiles[k], 1 ) );
+        for (int k=0; k<quantiles.size(); k++ ){
+          // asymptotic as chi2
+          //clsb_vals.push_back( TMath::Prob( quantiles[k], 1 ) );
+          // from toys
+          clsb_vals.push_back( getVectorFracAboveValue( sampledSBValues[i], quantiles[k] ) );
+        }
+
+        // check
+        if ( arg->debug ) {
+          cout << i << endl;
+          cout << "Quants: ";
+          for (int k=0; k<quantiles.size(); k++) cout << quantiles[k] << " , ";
+          cout << endl;
+          cout << "CLb: ";
+          for (int k=0; k<clb_vals.size(); k++) cout << clb_vals[k] << " , ";
+          cout << endl;
+          cout << "CLsb: ";
+          for (int k=0; k<clsb_vals.size(); k++) cout << clsb_vals[k] << " , ";
+          cout << endl;
+          cout << "CLs: ";
+          for (int k=0; k<clsb_vals.size(); k++) cout << clsb_vals[k]/clb_vals[k] << " , ";
+          cout << endl;
+        }
+
+        // hCLsExp->SetBinContent   ( i, TMath::Min( clsb_vals[2] / clb_vals[2] , 1.) );
+        // hCLsErr1Up->SetBinContent( i, TMath::Min( clsb_vals[1] / clb_vals[1] , 1.) );
+        // hCLsErr1Dn->SetBinContent( i, TMath::Min( clsb_vals[3] / clb_vals[3] , 1.) );
+        // hCLsErr2Up->SetBinContent( i, TMath::Min( clsb_vals[0] / clb_vals[0] , 1.) );
+        // hCLsErr2Dn->SetBinContent( i, TMath::Min( clsb_vals[4] / clb_vals[4] , 1.) );
+        hCLsExp->SetBinContent   ( i, TMath::Min( clsb_vals[2] , 1.) );
+        hCLsErr1Up->SetBinContent( i, TMath::Min( clsb_vals[1] , 1.) );
+        hCLsErr1Dn->SetBinContent( i, TMath::Min( clsb_vals[3] , 1.) );
+        hCLsErr2Up->SetBinContent( i, TMath::Min( clsb_vals[0] , 1.) );
+        hCLsErr2Dn->SetBinContent( i, TMath::Min( clsb_vals[4] , 1.) );
+
 	}
 
 	// goodness-of-fit

--- a/core/src/MethodPluginScan.cpp
+++ b/core/src/MethodPluginScan.cpp
@@ -824,22 +824,6 @@ TH1F* MethodPluginScan::analyseToys(ToyTree* t, int id)
 	Long64_t nwrongrun = 0;
 	Long64_t ntoysid   = 0; // if id is not -1, this will count the number of toys with that id
 
-	delete hCLsExp;
-    hCLsExp = new TH1F("hCLsExp", "hCLs", t->getScanpointN(), t->getScanpointMin() - halfBinWidth, t->getScanpointMax() + halfBinWidth);
-    delete hCLsErr1Up;
-    hCLsErr1Up = new TH1F("hCLsErr1Up", "hCLs", t->getScanpointN(), t->getScanpointMin() - halfBinWidth, t->getScanpointMax() + halfBinWidth);
-    delete hCLsErr1Dn;
-    hCLsErr1Dn = new TH1F("hCLsErr1Dn", "hCLs", t->getScanpointN(), t->getScanpointMin() - halfBinWidth, t->getScanpointMax() + halfBinWidth);
-    delete hCLsErr2Up;
-    hCLsErr2Up = new TH1F("hCLsErr2Up", "hCLs", t->getScanpointN(), t->getScanpointMin() - halfBinWidth, t->getScanpointMax() + halfBinWidth);
-    delete hCLsErr2Dn;
-    hCLsErr2Dn = new TH1F("hCLsErr2Dn", "hCLs", t->getScanpointN(), t->getScanpointMin() - halfBinWidth, t->getScanpointMax() + halfBinWidth);
-
-    // map of vectors for CLb quantiles
-    std::map<int,std::vector<double> > sampledBValues;
-    std::map<int,std::vector<double> > sampledSBValues;
-
-
 	t->activateCoreBranchesOnly(); // speeds up the event loop
 	ProgressBar pb(arg, nentries);
 	if ( arg->debug ) cout << "MethodPluginScan::analyseToys() : ";
@@ -902,17 +886,6 @@ TH1F* MethodPluginScan::analyseToys(ToyTree* t, int id)
 		if ( !inPhysicalRegion ){
 			h_background->Fill(t->scanpoint);
 		}
-
-		// sample the distribution of the background test statistic as the test statistic in the lowest bin
-		int hBin = h_all->FindBin(t->scanpoint);
-		if (t->scanpoint==t->getScanpointMin()){
-        	double bkgTestStatVal = t->chi2minToy - t->chi2minGlobalToy;
-        	bkgTestStatVal = t->scanbest <= t->scanpoint ? bkgTestStatVal : 0.;  // if muhat < mu then q_mu = 0
-        	sampledBValues[hBin].push_back( bkgTestStatVal );
-    	}
-        double sbTestStatVal = t->chi2minToy - t->chi2minGlobalToy;
-        sbTestStatVal = t->scanbest <= t->scanpoint ? sbTestStatVal : 0.; // if muhat < mu then q_mu = 0
-        sampledSBValues[hBin].push_back( sbTestStatVal );		
 	}
 
 	if ( arg->debug ) cout << "MethodPluginScan::analyseToys() : ";
@@ -956,48 +929,6 @@ TH1F* MethodPluginScan::analyseToys(ToyTree* t, int id)
 		float p_bkg = TMath::Min(p/hCL->GetBinContent(1), 1.);
 		hCLsFreq->SetBinContent(i, p_bkg);
 		hCLsFreq->SetBinError(i, sqrt(p_bkg * (1.-p_bkg)/nall));
-
-		        // the quantiles of the CLb distribution (for expected CLs)
-        std::vector<double> probs  = { TMath::Prob(4,1), TMath::Prob(1,1), 0.5, 1.-TMath::Prob(1,1), 1.-TMath::Prob(4,1) };
-        std::vector<double> clb_vals  = { 1.-TMath::Prob(4,1), 1.-TMath::Prob(1,1), 0.5, TMath::Prob(1,1), TMath::Prob(4,1) };
-        std::vector<double> quantiles = Quantile<double>( sampledBValues[i], probs );
-        std::vector<double> clsb_vals;
-        //for (int k=0; k<quantiles.size(); k++) clsb_vals.push_back( TMath::Prob( quantiles[k], 1 ) );
-        for (int k=0; k<quantiles.size(); k++ ){
-          // asymptotic as chi2
-          //clsb_vals.push_back( TMath::Prob( quantiles[k], 1 ) );
-          // from toys
-          clsb_vals.push_back( getVectorFracAboveValue( sampledSBValues[i], quantiles[k] ) );
-        }
-
-        // check
-        if ( arg->debug ) {
-          cout << i << endl;
-          cout << "Quants: ";
-          for (int k=0; k<quantiles.size(); k++) cout << quantiles[k] << " , ";
-          cout << endl;
-          cout << "CLb: ";
-          for (int k=0; k<clb_vals.size(); k++) cout << clb_vals[k] << " , ";
-          cout << endl;
-          cout << "CLsb: ";
-          for (int k=0; k<clsb_vals.size(); k++) cout << clsb_vals[k] << " , ";
-          cout << endl;
-          cout << "CLs: ";
-          for (int k=0; k<clsb_vals.size(); k++) cout << clsb_vals[k]/clb_vals[k] << " , ";
-          cout << endl;
-        }
-
-        // hCLsExp->SetBinContent   ( i, TMath::Min( clsb_vals[2] / clb_vals[2] , 1.) );
-        // hCLsErr1Up->SetBinContent( i, TMath::Min( clsb_vals[1] / clb_vals[1] , 1.) );
-        // hCLsErr1Dn->SetBinContent( i, TMath::Min( clsb_vals[3] / clb_vals[3] , 1.) );
-        // hCLsErr2Up->SetBinContent( i, TMath::Min( clsb_vals[0] / clb_vals[0] , 1.) );
-        // hCLsErr2Dn->SetBinContent( i, TMath::Min( clsb_vals[4] / clb_vals[4] , 1.) );
-        hCLsExp->SetBinContent   ( i, TMath::Min( clsb_vals[2] , 1.) );
-        hCLsErr1Up->SetBinContent( i, TMath::Min( clsb_vals[1] , 1.) );
-        hCLsErr1Dn->SetBinContent( i, TMath::Min( clsb_vals[3] , 1.) );
-        hCLsErr2Up->SetBinContent( i, TMath::Min( clsb_vals[0] , 1.) );
-        hCLsErr2Dn->SetBinContent( i, TMath::Min( clsb_vals[4] , 1.) );
-
 	}
 
 	// goodness-of-fit

--- a/core/src/MethodProbScan.cpp
+++ b/core/src/MethodProbScan.cpp
@@ -228,6 +228,10 @@ int MethodProbScan::scan1d(bool fast, bool reverse)
 
 			double deltaChi2 = chi2minScan - chi2minGlobal;
 			double oneMinusCL = TMath::Prob(deltaChi2, 1);
+			double deltaChi2Bkg = TMath::Max(chi2minScan - hChi2min->GetBinContent(1), 0.0);
+			if(i==0) deltaChi2Bkg = 0.0;
+			double oneMinusCLBkg = TMath::Prob(deltaChi2Bkg, 1);
+			hCLs->SetBinContent(hCLs->FindBin(scanvalue), oneMinusCLBkg);
 
 			// Save the 1-CL value and the corresponding fit result.
 			// But only if better than before!
@@ -237,7 +241,6 @@ int MethodProbScan::scan1d(bool fast, bool reverse)
 				int iRes = hCL->FindBin(scanvalue)-1;
 				curveResults[iRes] = r;
 			}
-
 			nStep++;
 		}
 	}

--- a/core/src/OneMinusClPlot.cpp
+++ b/core/src/OneMinusClPlot.cpp
@@ -150,6 +150,8 @@ TGraph* OneMinusClPlot::scan1dPlot(MethodAbsScan* s, bool first, bool last, bool
     if ( last && arg->isQuickhack(25) ) g->SetLineWidth(3);
 	}
 
+	if (CLsType>0) g->SetLineColor(s->getLineColor() - 1);
+
 	if ( plotPoints ){
 		g->SetLineWidth(1);
 		g->SetMarkerColor(color);
@@ -367,7 +369,10 @@ void OneMinusClPlot::scan1dCLsPlot(MethodAbsScan *s, bool smooth, bool obsError)
   }
   m_mainCanvas->cd();
 
-  s->checkCLs();
+  if(!s->checkCLs()){
+  		std::cout << "OneMinusClPlot::scan1dCLsPlot() : Cannot plot." << std::endl;
+  		return;
+  }
 
   TH1F *hObs    = (TH1F*)s->getHCLsFreq()->Clone(getUniqueRootName());
   TH1F *hExp    = (TH1F*)s->getHCLsExp()->Clone(getUniqueRootName());

--- a/core/src/OneMinusClPlot.cpp
+++ b/core/src/OneMinusClPlot.cpp
@@ -123,24 +123,24 @@ TGraph* OneMinusClPlot::scan1dPlot(MethodAbsScan* s, bool first, bool last, bool
 
 	int color = s->getLineColor();
 	if(CLsType>0 && s->getMethodName().Contains("Plugin") && !arg->plotpluginonly) {
-    if (CLsType==1) color = kBlue-7;
-    else if (CLsType==2) color = kBlue+2;
-  }
+    	if (CLsType==1) color = kBlue-7;
+    	else if (CLsType==2) color = kBlue+2;
+  	}
 	else if(CLsType>0) {
-    if (CLsType==1) color = s->getLineColor() - 5;
-    if (CLsType==2) color = s->getLineColor() - 4;
-  }
+    	if (CLsType==1) color = s->getLineColor() - 5;
+    	if (CLsType==2) color = s->getLineColor() - 4;
+  	}
 	g->SetLineColor(color);
 
 	if ( filled ){
-    double alpha = arg->isQuickhack(12) ? 0.4 : 1.;
-    if ( arg->isQuickhack(24) ) alpha = 0.;
-		if (s->getFillColor()>0) g->SetFillColorAlpha(s->getFillColor(), alpha);
-    else g->SetFillColorAlpha(color,alpha);
-    g->SetFillStyle( s->getFillStyle() );
+    	double alpha = arg->isQuickhack(12) ? 0.4 : 1.;
+    	if ( arg->isQuickhack(24) ) alpha = 0.;
+		if (s->getFillColor()>0 && CLsType==0) g->SetFillColorAlpha(s->getFillColor(), alpha);
+    	else g->SetFillColorAlpha(color,alpha);
+    	g->SetFillStyle( s->getFillStyle() );
 		g->SetLineWidth( s->getLineWidth() );
 		g->SetLineStyle( s->getLineStyle() );
-    g->SetLineColor( s->getLineColor() );
+    	g->SetLineColor( s->getLineColor() );
 	}
 	else{
 		g->SetLineWidth( s->getLineWidth() );

--- a/core/src/OneMinusClPlotAbs.cpp
+++ b/core/src/OneMinusClPlotAbs.cpp
@@ -50,10 +50,10 @@ void OneMinusClPlotAbs::addScanner(MethodAbsScan* s, int CLsType)
 		scanners.push_back(s);
 		do_CLs.push_back(CLsType);
 	}
-	else if ((CLsType==1 && !s->getHCLs()) || (CLsType==2 && !s->getHCLsFreq()))
-	{
-		cout << "No CLs histogram was determined. Will not plot." << endl;
-	}
+	// else if ((CLsType==1 && !s->getHCLs()) || (CLsType==2 && !s->getHCLsFreq()))
+	// {
+	// 	cout << "No CLs histogram was determined. Will not plot." << endl;
+	// }
 }
 
 ///

--- a/core/src/OptParser.cpp
+++ b/core/src/OptParser.cpp
@@ -766,12 +766,32 @@ void OptParser::parseArguments(int argc, char* argv[])
 	if ( isIn<TString>(bookedOptions, "color" ) ) cmd.add(colorArg);
 	if ( isIn<TString>(bookedOptions, "cls" ) ) cmd.add(clsArg);
 	if ( isIn<TString>(bookedOptions, "CL" ) ) cmd.add(CLArg);
-  if ( isIn<TString>(bookedOptions, "batchstartn" ) ) cmd.add( batchstartnArg );
-  if ( isIn<TString>(bookedOptions, "batcheos" ) ) cmd.add(batcheosArg);
+  	if ( isIn<TString>(bookedOptions, "batchstartn" ) ) cmd.add( batchstartnArg );
+  	if ( isIn<TString>(bookedOptions, "batcheos" ) ) cmd.add(batcheosArg);
 	if ( isIn<TString>(bookedOptions, "asimovfile" ) ) cmd.add( asimovFileArg );
 	if ( isIn<TString>(bookedOptions, "asimov") ) cmd.add(asimovArg);
 	if ( isIn<TString>(bookedOptions, "action") ) cmd.add(actionArg);
-	cmd.parse( argc, argv );
+
+
+	// check if the first argument is an integer. This will be discarded as a jobnumber.
+	const int num_of_args=argc-1;
+  	std::string jobnumber (argv[1]);
+  	std::stringstream str(jobnumber);
+  	int number;
+  	str >> number;
+  	if(str){
+	  	std::cout << "Use jobnumber " << number << std::endl;
+		char* args[num_of_args];
+
+	  	//remove jobnumber from cmdline string
+	  	for (int i = 0; i < argc; ++i)
+	    {
+	      if(i<1) args[i] = argv[i];
+	      if(i>1) args[i-1] = argv[i];
+	    }
+		cmd.parse( num_of_args, args );  		
+  	}
+	else cmd.parse( argc, argv );
 
 	//
 	// copy over parsed values into data members

--- a/core/src/PDF_Datasets.cpp
+++ b/core/src/PDF_Datasets.cpp
@@ -330,7 +330,6 @@ RooFitResult* PDF_Datasets::fitBkg(RooDataSet* dataToFit) {
     // unfortunately Minuit2 does not initialize the status of the roofitresult, if all parameters are constant. Therefore need to stay with standard Minuit fitting.
     // RooFitResult* result  = pdfBkg->fitTo( *dataToFit, RooFit::Save() , RooFit::ExternalConstraints(*this->getWorkspace()->set(constraintName)), RooFit::Minimizer("Minuit2", "Migrad"));
     RooFitResult* result  = pdfBkg->fitTo( *dataToFit, RooFit::Save() , RooFit::ExternalConstraints(*this->getWorkspace()->set(constraintName)));
-    result->Print("v");
     RooMsgService::instance().setSilentMode(kFALSE);
     RooMsgService::instance().setGlobalKillBelow(INFO);
     this->fitStatus = result->status();

--- a/core/src/ToyTree.cpp
+++ b/core/src/ToyTree.cpp
@@ -50,9 +50,11 @@ void ToyTree::initMembers(TChain* t){
 	chi2minGlobalToy    = 0.;
 	chi2minBkgToy       = 0.;
 	chi2minGlobalBkgToy = 0.;
+	chi2minBkgBkgToy 	= 0.;
 	scanbest            = 0.;
 	scanbesty           = 0.;
 	scanbestBkg         = 0.;
+	scanbestBkgfitBkg   = 0.;
 	nrun                = 0.;
 	ntoy                = 0.;
 	npoint              = 0.;
@@ -142,8 +144,9 @@ void ToyTree::init()
 	t->Branch("chi2minGlobal",       &chi2minGlobal,       "chi2minGlobal/F");
 	t->Branch("chi2minGlobalToy",    &chi2minGlobalToy,    "chi2minGlobalToy/F");
 	t->Branch("chi2minGlobalBkgToy", &chi2minGlobalBkgToy, "chi2minGlobalBkgToy/F");
-	t->Branch("chi2minBkg",    	     &chi2minBkg,		       "chi2minBkg/F");
-	t->Branch("chi2minBkgToy", 	     &chi2minBkgToy,     	 "chi2minBkgToy/F");
+	t->Branch("chi2minBkgBkgToy", 	 &chi2minBkgBkgToy,    "chi2minBkgBkgToy/F");
+	t->Branch("chi2minBkg",    	     &chi2minBkg,		   "chi2minBkg/F");
+	t->Branch("chi2minBkgToy", 	     &chi2minBkgToy,       "chi2minBkgToy/F");
 	t->Branch("covQualFree",         &covQualFree,         "covQualFree/F");
 	t->Branch("covQualScan",         &covQualScan,         "covQualScan/F");
 	t->Branch("covQualScanData",     &covQualScanData,     "covQualScanData/F");
@@ -156,6 +159,7 @@ void ToyTree::init()
 	t->Branch("scanbest",            &scanbest,            "scanbest/F");
 	t->Branch("scanbesty",           &scanbesty,           "scanbesty/F");
 	t->Branch("scanbestBkg",         &scanbestBkg,         "scanbestBkg/F");
+	t->Branch("scanbestBkgfitBkg",   &scanbestBkgfitBkg,   "scanbestBkgfitBkg/F");
 	t->Branch("scanpoint",           &scanpoint,           "scanpoint/F");
 	t->Branch("scanpointy",          &scanpointy,          "scanpointy/F");
 	t->Branch("statusFree",          &statusFree,          "statusFree/F");
@@ -223,6 +227,7 @@ void ToyTree::open()
 	if(branches->FindObject("chi2minGlobal"      )) t->SetBranchAddress("chi2minGlobal",      &chi2minGlobal);
 	if(branches->FindObject("chi2minGlobalToy"   )) t->SetBranchAddress("chi2minGlobalToy",   &chi2minGlobalToy);
 	if(branches->FindObject("chi2minGlobalBkgToy")) t->SetBranchAddress("chi2minGlobalBkgToy",&chi2minGlobalBkgToy);
+	if(branches->FindObject("chi2minBkgBkgToy"	 )) t->SetBranchAddress("chi2minBkgBkgToy",	  &chi2minBkgBkgToy);
 	if(branches->FindObject("chi2minBkg"      	 )) t->SetBranchAddress("chi2minBkg",      	  &chi2minBkg);
 	if(branches->FindObject("chi2minBkgToy"   	 )) t->SetBranchAddress("chi2minBkgToy",   	  &chi2minBkgToy);
 	if(branches->FindObject("covQualFree"        )) t->SetBranchAddress("covQualFree",        &covQualFree);
@@ -233,6 +238,7 @@ void ToyTree::open()
 	if(branches->FindObject("scanbest"           )) t->SetBranchAddress("scanbest",           &scanbest);
 	if(branches->FindObject("scanbesty"          )) t->SetBranchAddress("scanbesty",          &scanbesty);
 	if(branches->FindObject("scanbestBkg"        )) t->SetBranchAddress("scanbestBkg",        &scanbestBkg);
+	if(branches->FindObject("scanbestBkgfitBkg"  )) t->SetBranchAddress("scanbestBkgfitBkg",  &scanbestBkgfitBkg);
 	if(branches->FindObject("scanpoint"          )) t->SetBranchAddress("scanpoint",          &scanpoint);
 	if(branches->FindObject("scanpointy"         )) t->SetBranchAddress("scanpointy",         &scanpointy);
 	if(branches->FindObject("statusFree"         )) t->SetBranchAddress("statusFree",         &statusFree);
@@ -262,6 +268,7 @@ void ToyTree::activateCoreBranchesOnly()
 	if(branches->FindObject("chi2minGlobal"))         t->SetBranchStatus("chi2minGlobal",      1);
 	if(branches->FindObject("chi2minGlobalToy"))      t->SetBranchStatus("chi2minGlobalToy",   1);
 	if(branches->FindObject("chi2minGlobalBkgToy"))   t->SetBranchStatus("chi2minGlobalBkgToy",1);
+	if(branches->FindObject("chi2minBkgBkgToy"))   	  t->SetBranchStatus("chi2minBkgBkgToy",   1);
 	if(branches->FindObject("chi2minBkg"))         	  t->SetBranchStatus("chi2minBkg",         1);
 	if(branches->FindObject("chi2minBkgToy"))      	  t->SetBranchStatus("chi2minBkgToy",      1);
 	if(branches->FindObject("genericProbPValue"))     t->SetBranchStatus("genericProbPValue",  1);

--- a/scripts/setup_lxplus.sh
+++ b/scripts/setup_lxplus.sh
@@ -1,5 +1,5 @@
-source /afs/cern.ch/sw/lcg/releases/ROOT/5.34.25-8ef6d/x86_64-slc6-gcc48-opt/bin/thisroot.sh
-source /afs/cern.ch/sw/lcg/releases/gcc/4.8.1/x86_64-slc6/setup.sh
+source /cvmfs/sft.cern.ch/lcg/releases/LCG_88/ROOT/6.08.06/x86_64-slc6-gcc62-opt/ROOT-env.sh
+source /cvmfs/sft.cern.ch/lcg/releases/LCG_88/gcc/6.2.0/x86_64-slc6/setup.sh
 export LD_LIBRARY_PATH=$PWD/build:$LD_LIBRARY_PATH
 export LD_LIBRARY_PATH=$PWD/build/gammacombo:$LD_LIBRARY_PATH
 export LD_LIBRARY_PATH=$PWD/build/biggammacombo:$LD_LIBRARY_PATH


### PR DESCRIPTION
This merge request contains two issues:
1) I allowed the combiners part to also have a proper cls method (including plotting the cls p values). It's the simple CLs for now, the CLs plot is not supported yet, since it needs significantly larger changes. This was done to have a proper fallback cls method with the counting experiment, if the mass fit does not give conclusive results.

2) Discovered a mistake in the CLs Freq (or so I think), because I found larger expected limits from the mass fit than from the counting experiment (for the B2Kemu analysis).
As far as I see, we need to define CLsb and Clb the following way:
for CLsb (standard): `(t.chi2minToy - t.chi2minGlobalToy) >= (t.chi2min - this->chi2minGlobal)`
for Clb: `(t.chi2minBkgBkgToy - t.chi2minGlobalBkgToy) >= (chi2minBkg - chi2minGlobal)`, where
`chi2minBkgBkgToy`  means: _fit the bkg toys with the bkg pdf_, and 
`chi2minGlobalBkgToy`  means: _fit the bkg toys with the full s+b pdf_

the q test statistic has still to be used for that, of course, but for convenience it is easier that way.
For the the CLs plot (which is to be determined on the bkg-only toys) I now defined the test statistics as
`bkgTestStatVal = t.chi2minBkgBkgToy - t.chi2minGlobalBkgToy`
and then 
`sbTestStatVal = t.chi2minBkgToy - t.chi2minGlobalBkgToy`
(`chi2minBkgToy` meaning _fit the bkg toys with parameter fixed to scanpoint_)
The expected CLs plots then the fraction of `sbTestStatVal>Quantile(bkgTestStatVal)`

I also took into account #163 and removed one normalisation of the CLs values which seemed to much. It looks good for the first plot. I am doing some expected limits now to validate this, before I merge it.
