### PR TITLE
Fix contours for 2d p-value histograms

### DIFF
--- a/core/src/ConfidenceContours.cpp
+++ b/core/src/ConfidenceContours.cpp
@@ -185,13 +185,13 @@ void ConfidenceContours::computeContours(TH2F* hist, histogramType type, int id)
 		if ( m_arg->plot2dcl[id]>0 ){
       for ( int i=0;i <m_nMaxContours; i++ ) {
         int cLev = m_nMaxContours-1-i;
-        histb->SetContourLevel( cLev, offset - TMath::Prob( (i+1)*(i+1), 1) );
+        histb->SetContourLevel( cLev, TMath::Prob( (i+1)*(i+1), 1) );
       }
 		}
 		else{
       for ( int i=0;i <m_nMaxContours; i++ ) {
         int cLev = m_nMaxContours-1-i;
-        histb->SetContourLevel( cLev, 1.-TMath::Prob( (i+1)*(i+1), 2) );
+        histb->SetContourLevel( cLev, TMath::Prob( (i+1)*(i+1), 2) );
       }
 		}
 	}

--- a/core/src/GammaComboEngine.cpp
+++ b/core/src/GammaComboEngine.cpp
@@ -2037,7 +2037,18 @@ void GammaComboEngine::scanDataSet()
 		{
 				if ( arg->isAction("pluginbatch") ){
 					MethodDatasetsProbScan* scannerProb = new MethodDatasetsProbScan( (PDF_Datasets*) pdf[0], arg);
-					make1dProbScan( scannerProb, 0 );
+					if ( FileExists( m_fnamebuilder->getFileNameScanner(scannerProb)) ) {
+							scannerProb->initScan();
+							scannerProb->loadScanner( m_fnamebuilder->getFileNameScanner(scannerProb));
+					}
+					else{
+							cout << "\nWARNING : Couldn't load the Prob scanner, will rerun the Prob" << endl;
+							cout <<   "          scan now. You should have run the Prob scan locally" << endl;
+							cout <<   "          before running the Plugin scan." << endl;
+							cout <<   "          missing file: " << m_fnamebuilder->getFileNameScanner(scannerProb) << endl;
+							cout << endl;
+							make1dProbScan(scannerProb, 0);
+					}
 					MethodDatasetsPluginScan *scannerPlugin = new MethodDatasetsPluginScan( scannerProb, (PDF_Datasets*) pdf[0], arg);
 					make1dPluginScan(scannerPlugin, 0 );
 				}

--- a/core/src/MethodDatasetsPluginScan.cpp
+++ b/core/src/MethodDatasetsPluginScan.cpp
@@ -523,11 +523,16 @@ void MethodDatasetsPluginScan::readScan1dTrees(int runMin, int runMax, TString f
           cout << endl;
         }
 
-        hCLsExp->SetBinContent   ( i, TMath::Min( clsb_vals[2] / clb_vals[2] , 1.) );
-        hCLsErr1Up->SetBinContent( i, TMath::Min( clsb_vals[1] / clb_vals[1] , 1.) );
-        hCLsErr1Dn->SetBinContent( i, TMath::Min( clsb_vals[3] / clb_vals[3] , 1.) );
-        hCLsErr2Up->SetBinContent( i, TMath::Min( clsb_vals[0] / clb_vals[0] , 1.) );
-        hCLsErr2Dn->SetBinContent( i, TMath::Min( clsb_vals[4] / clb_vals[4] , 1.) );
+        // hCLsExp->SetBinContent   ( i, TMath::Min( clsb_vals[2] / clb_vals[2] , 1.) );
+        // hCLsErr1Up->SetBinContent( i, TMath::Min( clsb_vals[1] / clb_vals[1] , 1.) );
+        // hCLsErr1Dn->SetBinContent( i, TMath::Min( clsb_vals[3] / clb_vals[3] , 1.) );
+        // hCLsErr2Up->SetBinContent( i, TMath::Min( clsb_vals[0] / clb_vals[0] , 1.) );
+        // hCLsErr2Dn->SetBinContent( i, TMath::Min( clsb_vals[4] / clb_vals[4] , 1.) );
+        hCLsExp->SetBinContent   ( i, TMath::Min( clsb_vals[2] , 1.) );
+        hCLsErr1Up->SetBinContent( i, TMath::Min( clsb_vals[1] , 1.) );
+        hCLsErr1Dn->SetBinContent( i, TMath::Min( clsb_vals[3] , 1.) );
+        hCLsErr2Up->SetBinContent( i, TMath::Min( clsb_vals[0] , 1.) );
+        hCLsErr2Dn->SetBinContent( i, TMath::Min( clsb_vals[4] , 1.) );
 
         //hCLsExp->SetBinContent   ( i, (float(nSBValsAboveBkg[2]) / sampledSBValues[i].size() ) / probs[2] );
         //hCLsErr1Up->SetBinContent( i, (float(nSBValsAboveBkg[1]) / sampledSBValues[i].size() ) / probs[1] );


### PR DESCRIPTION
The contour levels for the p-value histograms in 2d were built the wrong way round, thus leading to very strange contours. 
Fixed this. With using the ``--smooth2d`` option the contours look fine again.