### PR TITLE
fixing prob cls limits for standard GammaCombo

### DIFF
--- a/core/include/ToyTree.h
+++ b/core/include/ToyTree.h
@@ -92,6 +92,12 @@ class ToyTree
 		float covQualFree;
 		float statusScan;
 		float covQualScan;
+		float statusFreeBkg;
+		float covQualFreeBkg;
+		float statusScanBkg;
+		float covQualScanBkg;
+		float statusBkgBkg;
+		float covQualBkgBkg;
 		float statusScanData;
 		float covQualScanData;
 		float nBergerBoos;

--- a/core/src/MethodAbsScan.cpp
+++ b/core/src/MethodAbsScan.cpp
@@ -719,6 +719,11 @@ void MethodAbsScan::calcCLintervals(int CLsType)
 			float y = 1.- ConfidenceLevels[c];
 			float sol = getScanVar1Solution(iSol);
 			int sBin = histogramCL->FindBin(sol);
+			std::cout << "solution bin: " << sBin << std::endl;
+			if(histogramCL->IsBinOverflow(sBin)||histogramCL->IsBinUnderflow(sBin)){
+				std::cout << "MethodAbsScan::calcCLintervals(): WARNING: no solution in scanrange found, will use lowest bin!" << std::endl;
+				sBin=1;
+			}
 
 			// find lower interval bound
 			for ( int i=sBin; i>0; i-- ){
@@ -1493,6 +1498,7 @@ void MethodAbsScan::calcCLintervalsSimple(int CLsType)
   {
     histogramCL = this->hCLsFreq;
   }
+
   if(CLsType==0 || (this->hCLs && CLsType==1) || (this->hCLsFreq && CLsType==2))
   {
 	  for (int c=0;c<3;c++){
@@ -1555,10 +1561,9 @@ const std::pair<double, double> MethodAbsScan::getBorders(const TGraph& graph, c
   TSpline* splines = NULL;
   if(qubic) splines = new TSpline3();
 
-
   double min_edge = graph.GetX()[0];
   // will never return smaller edge than min_edge
-  double max_edge = graph.GetX()[graph.GetN()-1];
+  double max_edge = graph.GetX()[graph.GetN()-2];
   // will never return higher edge than max_edge
   int scan_steps = 1000;
   double lower_edge = min_edge;

--- a/core/src/MethodDatasetsPluginScan.cpp
+++ b/core/src/MethodDatasetsPluginScan.cpp
@@ -102,27 +102,29 @@ void MethodDatasetsPluginScan::initScan() {
         pdf->printParameters();
         exit(EXIT_FAILURE);
     }
-    if ( arg->scanrangeMin != arg->scanrangeMax ) par1->setRange("scan", arg->scanrangeMin, arg->scanrangeMax);
-    Utils::setLimit(w, scanVar1, "scan");
+    // if ( arg->scanrangeMin != arg->scanrangeMax ) par1->setRange("scan", arg->scanrangeMin, arg->scanrangeMax);
+    // Utils::setLimit(w, scanVar1, "scan");
+    float min1 = arg->scanrangeMin;
+    float max1 = arg->scanrangeMax;
 
     if (hCL) delete hCL;
-    hCL = new TH1F("hCL" + getUniqueRootName(), "hCL" + pdf->getPdfName(), nPoints1d, par1->getMin(), par1->getMax());
+    hCL = new TH1F("hCL" + getUniqueRootName(), "hCL" + pdf->getPdfName(), nPoints1d, min1, max1);
     if (hCLs) delete hCLs;
-    hCLs = new TH1F("hCLs" + getUniqueRootName(), "hCLs" + pdf->getPdfName(), nPoints1d, par1->getMin(), par1->getMax());
+    hCLs = new TH1F("hCLs" + getUniqueRootName(), "hCLs" + pdf->getPdfName(), nPoints1d, min1, max1);
     if (hCLsFreq) delete hCLsFreq;
-    hCLsFreq = new TH1F("hCLsFreq" + getUniqueRootName(), "hCLsFreq" + pdf->getPdfName(), nPoints1d, par1->getMin(), par1->getMax());
+    hCLsFreq = new TH1F("hCLsFreq" + getUniqueRootName(), "hCLsFreq" + pdf->getPdfName(), nPoints1d, min1, max1);
     if (hCLsExp) delete hCLsExp;
-    hCLsExp = new TH1F("hCLsExp" + getUniqueRootName(), "hCLsExp" + pdf->getPdfName(), nPoints1d, par1->getMin(), par1->getMax());
+    hCLsExp = new TH1F("hCLsExp" + getUniqueRootName(), "hCLsExp" + pdf->getPdfName(), nPoints1d, min1, max1);
     if (hCLsErr1Up) delete hCLsErr1Up;
-    hCLsErr1Up = new TH1F("hCLsErr1Up" + getUniqueRootName(), "hCLsErr1Up" + pdf->getPdfName(), nPoints1d, par1->getMin(), par1->getMax());
+    hCLsErr1Up = new TH1F("hCLsErr1Up" + getUniqueRootName(), "hCLsErr1Up" + pdf->getPdfName(), nPoints1d, min1, max1);
     if (hCLsErr1Dn) delete hCLsErr1Dn;
-    hCLsErr1Dn = new TH1F("hCLsErr1Dn" + getUniqueRootName(), "hCLsErr1Dn" + pdf->getPdfName(), nPoints1d, par1->getMin(), par1->getMax());
+    hCLsErr1Dn = new TH1F("hCLsErr1Dn" + getUniqueRootName(), "hCLsErr1Dn" + pdf->getPdfName(), nPoints1d, min1, max1);
     if (hCLsErr2Up) delete hCLsErr2Up;
-    hCLsErr2Up = new TH1F("hCLsErr2Up" + getUniqueRootName(), "hCLsErr2Up" + pdf->getPdfName(), nPoints1d, par1->getMin(), par1->getMax());
+    hCLsErr2Up = new TH1F("hCLsErr2Up" + getUniqueRootName(), "hCLsErr2Up" + pdf->getPdfName(), nPoints1d, min1, max1);
     if (hCLsErr2Dn) delete hCLsErr2Dn;
-    hCLsErr2Dn = new TH1F("hCLsErr2Dn" + getUniqueRootName(), "hCLsErr2Dn" + pdf->getPdfName(), nPoints1d, par1->getMin(), par1->getMax());
+    hCLsErr2Dn = new TH1F("hCLsErr2Dn" + getUniqueRootName(), "hCLsErr2Dn" + pdf->getPdfName(), nPoints1d, min1, max1);
     if ( hChi2min ) delete hChi2min;
-    hChi2min = new TH1F("hChi2min" + getUniqueRootName(), "hChi2min" + pdf->getPdfName(), nPoints1d, par1->getMin(), par1->getMax());
+    hChi2min = new TH1F("hChi2min" + getUniqueRootName(), "hChi2min" + pdf->getPdfName(), nPoints1d, min1, max1);
 
     // fill the chi2 histogram with very unlikely values such
     // that inside scan1d() the if clauses work correctly
@@ -367,7 +369,7 @@ void MethodDatasetsPluginScan::readScan1dTrees(int runMin, int runMax, TString f
     // histogram illustrating the failure rate
     TH1F *h_fracGoodToys  = (TH1F*)hCL->Clone("h_fracGoodToys");
 
-    TH1F *bkg_pvals  = new TH1F("bkg_pvals", "bkg p values", 20, -0.1, 1.1);
+    TH1F *bkg_pvals  = new TH1F("bkg_pvals", "bkg p values", 20, -0.0001, 1.0001);
 
     // map of vectors for CLb quantiles
     std::map<int,std::vector<double> > sampledBValues;
@@ -401,9 +403,10 @@ void MethodDatasetsPluginScan::readScan1dTrees(int runMin, int runMax, TString f
         h_tot->Fill(t.scanpoint);
         if (t.scanpoint == 0.0) n0tot++;
         // criteria for GammaCombo
-        bool convergedFits      = (t.statusFree == 0. && t.statusScan == 0.);
+        bool convergedFits      = (t.statusFree == 0. && t.statusScan == 0.) && (t.covQualFree == 3 && t.covQualScan == 3);
         bool tooHighLikelihood  = !( abs(t.chi2minToy) < 1e27 && abs(t.chi2minGlobalToy) < 1e27);
-        bool BadBkgFit          = t.chi2minBkgBkgToy - t.chi2minGlobalBkgToy <= 0;
+        bool BadBkgFit          = !(t.statusFreeBkg == 0 && t.statusBkgBkg == 0) && (t.covQualFreeBkg == 3 && t.covQualBkgBkg == 3);
+        // bool BadBkgFit          = false;
 
         // apply cuts
         if ( tooHighLikelihood || !convergedFits )
@@ -416,6 +419,7 @@ void MethodDatasetsPluginScan::readScan1dTrees(int runMin, int runMax, TString f
         }
 
         if ( BadBkgFit){
+            std::cout << "Failed because of "  << t.statusFreeBkg << t.statusBkgBkg << t.covQualFreeBkg << t.covQualBkgBkg << std::endl;
             nfailedbkg++;
         }
 
@@ -474,6 +478,7 @@ void MethodDatasetsPluginScan::readScan1dTrees(int runMin, int runMax, TString f
         double bkgTestStatVal = t.chi2minBkgBkgToy - t.chi2minGlobalBkgToy;
         
         if( !BadBkgFit ){
+            // bkgTestStatVal = t.scanbestBkgfitBkg <= 0. ? bkgTestStatVal : 0.;  // if muhat < mu then q_mu = 0
             if(hBin==1){
                 bkg_pvals->Fill(TMath::Prob(bkgTestStatVal,1));
             }
@@ -756,6 +761,10 @@ int MethodDatasetsPluginScan::scan1d(int nRun)
     vector<float> chi2minBkgBkgToysStore;       // Bkg fit to bkg-only toys
     vector<float> scanbestBkgToysStore;         // best fit point of gloabl fit to bkg-only toys 
     vector<float> scanbestBkgBkgToysStore;      // best fit point of bkg fit to bkg-only toys (usually zero because bkg pdf will not depend on signal parameter)
+    vector<int> covQualFreeBkgToysStore;      // covariance quality of gloabl fit to bkg-only toys 
+    vector<int> covQualBkgBkgToysStore;       // covariance quality of bkg fit to bkg-only toys 
+    vector<int> StatusFreeBkgToysStore;       // status of gloabl fit to bkg-only toys 
+    vector<int> StatusBkgBkgToysStore;        // status of bkg fit to bkg-only toys
     // Titus: Try importance sampling from the combination part -> works, but definitely needs improvement in precision
     int nActualToys = nToys;
     if ( arg->importance ){
@@ -800,6 +809,12 @@ int MethodDatasetsPluginScan::scan1d(int nRun)
                   << "++++ > status: " << pdf->getFitStatus() << endl;
             pdf->setFitStatus(-99);
         }
+        if (rb->edm()>1.e-4) {
+            cout  << "++++ > Fit not converged: "  << endl
+                  << "++++ > edm: " << rb->edm() << endl
+                  << "++++ > status: " << -60 << endl;
+            pdf->setFitStatus(-60);
+        }
         pdf->setMinNllScan(pdf->minNll);
 
         // chi2minGlobalBkgToysStore.push_back( 2 * rb->minNll() );
@@ -809,6 +824,8 @@ int MethodDatasetsPluginScan::scan1d(int nRun)
         }
         // if the pdf does not depend on the signal parameter, set best fit value of signa l parameter for the bkg fit to 0
         else scanbestBkgToysStore.push_back(0.0);
+        covQualFreeBkgToysStore.push_back(rb->covQual());
+        StatusFreeBkgToysStore.push_back(pdf->getFitStatus());
 
         delete rb;
         rb = pdf->fitBkg(bkgOnlyToy);
@@ -828,6 +845,12 @@ int MethodDatasetsPluginScan::scan1d(int nRun)
                 assert(rb);
             }
         }
+        if (rb->edm()>1.e-4) {
+            cout  << "++++ > Bkg Fit not converged: "  << endl
+                  << "++++ > edm: " << rb->edm() << endl
+                  << "++++ > status: " << -60 << endl;
+            pdf->setFitStatus(-60);
+        }
         // chi2minBkgBkgToysStore.push_back( 2 * rb->minNll() );
         chi2minBkgBkgToysStore.push_back( 2 * pdf->getMinNllBkg() );
         if(rb->floatParsFinal().find(pdf->getParName())){
@@ -835,6 +858,9 @@ int MethodDatasetsPluginScan::scan1d(int nRun)
         }
         // if the pdf does not depend on the signal parameter, set best fit value of signa l parameter for the bkg fit to 0
         else scanbestBkgBkgToysStore.push_back(0.0);
+        covQualBkgBkgToysStore.push_back(rb->covQual());
+        StatusBkgBkgToysStore.push_back(pdf->getFitStatus());
+
         delete rb;
         pdf->deleteToys();
       }
@@ -1044,6 +1070,8 @@ int MethodDatasetsPluginScan::scan1d(int nRun)
             // toyTree.chi2minBkgToy          = 2 * rb->minNll(); // 2*r->minNll(); //2*r->minNll();
             toyTree.chi2minBkgToy          = 2 * pdf->getMinNll(); // 2*r->minNll(); //2*r->minNll();
             toyTree.chi2minBkgToyPDF       = 2 * pdf->getMinNllScan();
+            toyTree.covQualScanBkg         = rb->covQual(); // 2*r->minNll(); //2*r->minNll();
+            toyTree.statusScanBkg          = pdf->getFitStatus();
 
             pdf->deleteNLL();
 
@@ -1119,6 +1147,11 @@ int MethodDatasetsPluginScan::scan1d(int nRun)
                         cout << "----> fit status: " << pdf->getFitStatus() << endl;
                         pdf->setFitStatus(-99);
                     }
+                    if (r1->edm()>1.e-4) {
+                        cout << "----> too large edm " << endl;
+                        cout << "----> edm: " << r1->edm() << endl;
+                        pdf->setFitStatus(-60);
+                    }
                     this->setAndPrintFitStatusConstrainedToys(toyTree);
 
                     if ( (toyTree.chi2minToy - toyTree.chi2minGlobalToy) < 0) {
@@ -1158,7 +1191,7 @@ int MethodDatasetsPluginScan::scan1d(int nRun)
                 }
             }
             // set the limit back again
-            setLimit(w, scanVar1, "scan");
+            // setLimit(w, scanVar1, "scan");
 
             // toyTree.chi2minGlobalToy    = 2 * r1->minNll(); //2*r1->minNll();
             toyTree.chi2minGlobalToy    = 2 * pdf->getMinNllFree(); //2*r1->minNll();
@@ -1178,13 +1211,23 @@ int MethodDatasetsPluginScan::scan1d(int nRun)
             //else {
             assert( chi2minGlobalBkgToysStore.size() == nToys );
             assert( scanbestBkgToysStore.size() == nToys );
+            assert( covQualFreeBkgToysStore.size() == nToys );
+            assert( StatusFreeBkgToysStore.size() == nToys );
+
             assert( chi2minBkgBkgToysStore.size() == nToys );
             assert( scanbestBkgBkgToysStore.size() == nToys );
+            assert( covQualBkgBkgToysStore.size() == nToys );
+            assert( StatusBkgBkgToysStore.size() == nToys );
             //}
             toyTree.chi2minGlobalBkgToy = chi2minGlobalBkgToysStore[j];
-            toyTree.scanbestBkg      = scanbestBkgToysStore[j];
-            toyTree.chi2minBkgBkgToy = chi2minBkgBkgToysStore[j];
-            toyTree.scanbestBkgfitBkg      = scanbestBkgBkgToysStore[j];
+            toyTree.scanbestBkg         = scanbestBkgToysStore[j];
+            toyTree.covQualFreeBkg      = covQualFreeBkgToysStore[j];
+            toyTree.statusFreeBkg       = StatusFreeBkgToysStore[j];
+
+            toyTree.chi2minBkgBkgToy    = chi2minBkgBkgToysStore[j];
+            toyTree.scanbestBkgfitBkg   = scanbestBkgBkgToysStore[j];
+            toyTree.covQualBkgBkg       = covQualBkgBkgToysStore[j];
+            toyTree.statusBkgBkg        = StatusBkgBkgToysStore[j];
 
             if (arg->debug) {
                 cout << "#### > Fit summary: " << endl;

--- a/core/src/MethodDatasetsProbScan.cpp
+++ b/core/src/MethodDatasetsProbScan.cpp
@@ -74,12 +74,14 @@ void MethodDatasetsProbScan::initScan() {
     if ( !m_xrangeset && arg->scanrangeMin != arg->scanrangeMax ) {
 			setXscanRange(arg->scanrangeMin,arg->scanrangeMax);
 		}
-    setLimit(w, scanVar1, "scan");
+    // setLimit(w, scanVar1, "scan");
 
     if (hCL) delete hCL;
     // Titus: small change for consistency
-    float min1 = par1->getMin();
-    float max1 = par1->getMax();
+    // float min1 = par1->getMin();
+    // float max1 = par1->getMax();
+    float min1 = arg->scanrangeMin;
+    float max1 = arg->scanrangeMax;
 
     hCL = new TH1F("hCL" + getUniqueRootName(), "hCL" + pdf->getPdfName(), nPoints1d, min1, max1);
     if ( hChi2min ) delete hChi2min;
@@ -110,9 +112,12 @@ void MethodDatasetsProbScan::initScan() {
         if ( !m_yrangeset && arg->scanrangeyMin != arg->scanrangeyMax ){
             setYscanRange(arg->scanrangeyMin,arg->scanrangeyMax);
         }
-        setLimit(w, scanVar2, "scan");
-        float min2 = par2->getMin();
-        float max2 = par2->getMax();
+        // setLimit(w, scanVar2, "scan");
+        // float min2 = par2->getMin();
+        // float max2 = par2->getMax();
+        float min2 = arg->scanrangeyMin;
+        float max2 = arg->scanrangeyMax;
+
         hCL2d      = new TH2F("hCL2d"+getUniqueRootName(),      "hCL2d"+pdfName, nPoints2dx, min1, max1, nPoints2dy, min2, max2);
         hCLs2d      = new TH2F("hCLs2d"+getUniqueRootName(),      "hCLs2d"+pdfName, nPoints2dx, min1, max1, nPoints2dy, min2, max2);
         hChi2min2d = new TH2F("hChi2min2d"+getUniqueRootName(), "hChi2min",      nPoints2dx, min1, max1, nPoints2dy, min2, max2);

--- a/core/src/OneMinusClPlot.cpp
+++ b/core/src/OneMinusClPlot.cpp
@@ -67,6 +67,8 @@ TGraph* OneMinusClPlot::scan1dPlot(MethodAbsScan* s, bool first, bool last, bool
 	if ( plotPoints ) g = new TGraphErrors(hCL->GetNbinsX());
 	else              g = new TGraph(hCL->GetNbinsX());
 	g->SetName(getUniqueRootName());
+
+
 	for ( int i=0; i<hCL->GetNbinsX(); i++ ){
 		g->SetPoint(i, hCL->GetBinCenter(i+1), hCL->GetBinContent(i+1));
 		if ( plotPoints ) ((TGraphErrors*)g)->SetPointError(i, 0.0, hCL->GetBinError(i+1));
@@ -92,6 +94,18 @@ TGraph* OneMinusClPlot::scan1dPlot(MethodAbsScan* s, bool first, bool last, bool
 	//   if ( plotPoints ) err0 = ((TGraphErrors*)g)->GetErrorY(0);
 	//   if ( plotPoints ) ((TGraphErrors*)g)->SetPointError(g->GetN()-1, 0.0, err0);
 	// }
+
+	// check whether a strong jump appears at the last point. That happens somehow for the CLs prob method when converting the histogram to TGraph
+	if ((g->GetY()[g->GetN()-1]-g->GetY()[g->GetN()-2])>0.5){
+		std::cout << "OneMinusClPlot::scan1dPlot() : Unexpected jump appears at the endpoint of graph. Removing it." << std::endl;
+		g->RemovePoint(g->GetN()-1);
+	}
+
+	// int nbins = g->GetN();
+	// for (int i=0; i<nbins; i++){
+	//    std::cout << g->GetY()[i] << std::endl;
+	// }
+
 
 	// add end points of scan range
 	if ( !plotPoints )

--- a/core/src/ToyTree.cpp
+++ b/core/src/ToyTree.cpp
@@ -61,12 +61,18 @@ void ToyTree::initMembers(TChain* t){
 	id                  = 0.;
 	statusFree          = -5.;
 	statusScan          = -5.;
+	statusFreeBkg       = -5.;
+	statusScanBkg       = -5.;
+	statusBkgBkg       = -5.;
 	statusScanData      = -5.;
 	nBergerBoos         = 0.;
 	BergerBoos_id       = 0.;
 	genericProbPValue   = 0.;
 	covQualFree         = -2.;
 	covQualScan         = -2.;
+	covQualFreeBkg         = -2.;
+	covQualScanBkg         = -2.;
+	covQualBkgBkg         = -2.;
 	covQualScanData     = -2.;
 	statusFreePDF       = -5.;
 	statusScanPDF       = -5.;
@@ -149,6 +155,9 @@ void ToyTree::init()
 	t->Branch("chi2minBkgToy", 	     &chi2minBkgToy,       "chi2minBkgToy/F");
 	t->Branch("covQualFree",         &covQualFree,         "covQualFree/F");
 	t->Branch("covQualScan",         &covQualScan,         "covQualScan/F");
+	t->Branch("covQualFreeBkg",      &covQualFreeBkg,      "covQualFreeBkg/F");
+	t->Branch("covQualScanBkg",      &covQualScanBkg,      "covQualScanBkg/F");
+	t->Branch("covQualBkgBkg",       &covQualBkgBkg,       "covQualBkgBkg/F");
 	t->Branch("covQualScanData",     &covQualScanData,     "covQualScanData/F");
 	t->Branch("genericProbPValue",   &genericProbPValue,   "genericProbPValue/F");
 	t->Branch("id",                  &id,                  "id/F");
@@ -165,6 +174,9 @@ void ToyTree::init()
 	t->Branch("statusFree",          &statusFree,          "statusFree/F");
 	t->Branch("statusScan",          &statusScan,          "statusScan/F");
 	t->Branch("statusScanData",      &statusScanData,      "statusScanData/F");
+	t->Branch("statusFreeBkg",       &statusFreeBkg,   		"statusFreeBkg/F");
+	t->Branch("statusScanBkg",       &statusScanBkg,    	"statusScanBkg/F");
+	t->Branch("statusBkgBkg",        &statusBkgBkg,        	"statusBkgBkg/F");
 	if ( !arg->lightfiles )
 	{
 		TIterator* it = w->set(parsName)->createIterator();
@@ -233,6 +245,9 @@ void ToyTree::open()
 	if(branches->FindObject("covQualFree"        )) t->SetBranchAddress("covQualFree",        &covQualFree);
 	if(branches->FindObject("covQualScan"        )) t->SetBranchAddress("covQualScan",        &covQualScan);
 	if(branches->FindObject("covQualScanData"    )) t->SetBranchAddress("covQualScanData",    &covQualScanData);
+	if(branches->FindObject("covQualFreeBkg"     )) t->SetBranchAddress("covQualFreeBkg",     &covQualFreeBkg);
+	if(branches->FindObject("covQualScanBkg"     )) t->SetBranchAddress("covQualScanBkg",     &covQualScanBkg);
+	if(branches->FindObject("covQualBkgBkg"      )) t->SetBranchAddress("covQualBkgBkg",      &covQualBkgBkg);
 	if(branches->FindObject("genericProbPValue"  )) t->SetBranchAddress("genericProbPValue",  &genericProbPValue);
 	if(branches->FindObject("nBergerBoos"        )) t->SetBranchAddress("nBergerBoos",        &nBergerBoos);
 	if(branches->FindObject("scanbest"           )) t->SetBranchAddress("scanbest",           &scanbest);
@@ -244,14 +259,17 @@ void ToyTree::open()
 	if(branches->FindObject("statusFree"         )) t->SetBranchAddress("statusFree",         &statusFree);
 	if(branches->FindObject("statusScan"         )) t->SetBranchAddress("statusScan",         &statusScan);
 	if(branches->FindObject("statusScanData"     )) t->SetBranchAddress("statusScanData",     &statusScanData);
+	if(branches->FindObject("statusFreeBkg"      )) t->SetBranchAddress("statusFreeBkg",      &statusFreeBkg);
+	if(branches->FindObject("statusScanBkg"      )) t->SetBranchAddress("statusScanBkg",      &statusScanBkg);
+	if(branches->FindObject("statusBkgBkg"       )) t->SetBranchAddress("statusBkgBkg",       &statusBkgBkg);
 	if(branches->FindObject("chi2minGlobalToyPDF")) t->SetBranchAddress("chi2minGlobalToyPDF",&chi2minGlobalToyPDF);
 	if(branches->FindObject("chi2minBkgToyPDF"	 )) t->SetBranchAddress("chi2minBkgToyPDF",	  &chi2minBkgToyPDF);
 	if(branches->FindObject("chi2minToyPDF"      )) t->SetBranchAddress("chi2minToyPDF",      &chi2minToyPDF);
-	if(branches->FindObject("covQualFree"        )) t->SetBranchAddress("covQualFree",        &covQualFree);
-	if(branches->FindObject("covQualScan"        )) t->SetBranchAddress("covQualScan",        &covQualScan);
-	if(branches->FindObject("covQualScanData"    )) t->SetBranchAddress("covQualScanData",    &covQualScanData);
+	// if(branches->FindObject("covQualFree"        )) t->SetBranchAddress("covQualFree",        &covQualFree);
+	// if(branches->FindObject("covQualScan"        )) t->SetBranchAddress("covQualScan",        &covQualScan);
+	// if(branches->FindObject("covQualScanData"    )) t->SetBranchAddress("covQualScanData",    &covQualScanData);
 	if(branches->FindObject("statusFreePDF"      )) t->SetBranchAddress("statusFreePDF",      &statusFreePDF);
-	if(branches->FindObject("statusScanData"     )) t->SetBranchAddress("statusScanData",     &statusScanData);
+	// if(branches->FindObject("statusScanData"     )) t->SetBranchAddress("statusScanData",     &statusScanData);
 	if(branches->FindObject("statusScanPDF"      )) t->SetBranchAddress("statusScanPDF",      &statusScanPDF);
 }
 


### PR DESCRIPTION
1) When using the cls method with the standard GammaCombo (e.g. for a counting experiment)
somehow in the conversion of the histograms to graphs an error happens so that the last point gets a 1 as entry. 
This only occurs, if there was no solution found. Reasons are not clear to me. But I implemented a workaround.

2) Datasets part: We need access to fit status and covariance quality of background toys also