### PR TITLE
Need to change cov matrix build to virtual func

### DIFF
--- a/core/include/PDF_Abs.h
+++ b/core/include/PDF_Abs.h
@@ -57,7 +57,7 @@ class PDF_Abs
 		virtual             ~PDF_Abs();
 		virtual void				build();
 		virtual void        buildPdf();
-		void                buildCov();
+		virtual void        buildCov();
 		bool                bkgpdfset(){return isBkgPdfSet;};
 		virtual bool        checkConsistency();
 		void                deleteToys(){delete toyObservables;};


### PR DESCRIPTION
There are actually cases where the user might want to overwrite this
function as is done the e.g. building the PDF. An example is when
making assumptions / studies with zero systematics and very many numbers
of observables (i.e. 2D binned distribution). In this case the default
cov matrix inversion is killed by the accuracy falling below threshold.