### PR TITLE
Bugfix for datasets part for newer ROOT versions

### DIFF
--- a/core/src/MethodDatasetsPluginScan.cpp
+++ b/core/src/MethodDatasetsPluginScan.cpp
@@ -810,7 +810,14 @@ void MethodDatasetsPluginScan::readScan1dTrees(int runMin, int runMax, TString f
         leg->AddEntry((TObject*)0,Form("#sigma=%4.2g +/- %4.2g",h_sig_bkgtoys->GetStdDev(),h_sig_bkgtoys->GetStdDevError()),"");
         leg->Draw("same");
         savePlot(biascanv, "bkg-only_toyfit");
-        hCLb-> Draw("PE");
+        hCLb->Draw("PE");
+        hCLb->GetXaxis()->SetTitle("POI value");
+        hCLb->GetYaxis()->SetTitle("CL_{b}");
+        hCLb->GetXaxis()->SetTitleSize(0.06);
+        hCLb->GetYaxis()->SetTitleSize(0.06);
+        hCLb->GetXaxis()->SetLabelSize(0.06);
+        hCLb->GetYaxis()->SetLabelSize(0.06);
+        hCLb->SetLineWidth(2);
         savePlot(biascanv, "CLb_values");
     }
 
@@ -1944,7 +1951,7 @@ void MethodDatasetsPluginScan::makeControlPlots(map<int, vector<double> > bVals,
 
     // double dataVal = TMath::ChisquareQuantile( 1.-hCL->GetBinContent(i),1 );
     double dataVal = hChi2min->GetBinContent(i);
-    std::cout << "CLb alternative: " << getVectorFracAboveValue( bVals[i], dataVal) << std::endl;
+    // std::cout << "CLb alternative: " << getVectorFracAboveValue( bVals[i], dataVal) << std::endl;
     TArrow *lD = new TArrow( dataVal, 0.6*hsb->GetMaximum(), dataVal, 0., 0.15, "|>" );
 
     vector<TLine*> qLs;

--- a/core/src/PDF_Datasets.cpp
+++ b/core/src/PDF_Datasets.cpp
@@ -51,6 +51,7 @@ void  PDF_Datasets::initConstraints(const TString& setName) {
         std::cout << "ERROR in PDF_B_MuMu::initConstraints - constraint pdf not initialized." << endl;
         exit(EXIT_FAILURE);
     }
+    if(data && pdf) minNll = pdf->createNLL(*data, RooFit::Extended(kTRUE), RooFit::ExternalConstraints(*getWorkspace()->set(constraintName)))->getVal();
 };
 
 void PDF_Datasets::initData(const TString& name) {
@@ -67,7 +68,7 @@ void PDF_Datasets::initData(const TString& name) {
         std::cout << "FATAL in PDF_Datasets::initData -- Data: " << dataName << " not found in workspace" << std::endl;
         exit(EXIT_FAILURE);
     }
-    if(pdf) this->minNll = pdf->createNLL(*data)->getVal();
+    if(pdf && getWorkspace()->obj(constraintName)) minNll = pdf->createNLL(*data, RooFit::Extended(kTRUE), RooFit::ExternalConstraints(*getWorkspace()->set(constraintName)))->getVal();
     std::cout << "INFO in PDF_Datasets::initData -- Data initialized" << std::endl;
     return;
 };
@@ -155,7 +156,7 @@ void PDF_Datasets::initPDF(const TString& name) {
     }
 
     std::cout << "INFO in PDF_Datasets::initPDF -- PDF initialized" << std::endl;
-    if(data) this->minNll = pdf->createNLL(*data)->getVal();
+    if(data && getWorkspace()->obj(constraintName)) minNll = pdf->createNLL(*data, RooFit::Extended(kTRUE), RooFit::ExternalConstraints(*getWorkspace()->set(constraintName)))->getVal();
     return;
 };
 
@@ -299,14 +300,14 @@ RooFitResult* PDF_Datasets::fit(RooDataSet* dataToFit) {
 
     // unfortunately Minuit2 does not initialize the status of the roofitresult, if all parameters are constant. Therefore need to stay with standard Minuit fitting.
     // RooFitResult* result  = pdf->fitTo( *dataToFit, RooFit::Save() , RooFit::ExternalConstraints(*this->getWorkspace()->set(constraintName)), RooFit::Minimizer("Minuit2", "Migrad"));
-    RooFitResult* result  = pdf->fitTo( *dataToFit, RooFit::Save() , RooFit::ExternalConstraints(*this->getWorkspace()->set(constraintName)), RooFit::Extended(kTRUE));
+    RooFitResult* result  = pdf->fitTo( *dataToFit, RooFit::Save() , RooFit::ExternalConstraints(*getWorkspace()->set(constraintName)), RooFit::Extended(kTRUE));
 
     RooMsgService::instance().setSilentMode(kFALSE);
     RooMsgService::instance().setGlobalKillBelow(INFO);
-    this->fitStatus = result->status();
+    fitStatus = result->status();
     // RooAbsReal* nll = pdf->createNLL(*dataToFit, RooFit::Extended(kTRUE));
-    RooAbsReal* nll = pdf->createNLL(*dataToFit, RooFit::Extended(kTRUE), RooFit::ExternalConstraints(*this->getWorkspace()->set(constraintName)));
-    this->minNll = nll->getVal();
+    RooAbsReal* nll = pdf->createNLL(*dataToFit, RooFit::Extended(kTRUE), RooFit::ExternalConstraints(*getWorkspace()->set(constraintName)));
+    minNll = nll->getVal();
     delete nll;
 
     return result;
@@ -344,14 +345,14 @@ RooFitResult* PDF_Datasets::fitBkg(RooDataSet* dataToFit) {
     // unfortunately Minuit2 does not initialize the status of the roofitresult, if all parameters are constant. Therefore need to stay with standard Minuit fitting.
     // RooFitResult* result  = pdfBkg->fitTo( *dataToFit, RooFit::Save() , RooFit::ExternalConstraints(*this->getWorkspace()->set(constraintName)), RooFit::Minimizer("Minuit2", "Migrad"));
 
-    RooFitResult* result  = pdf->fitTo( *dataToFit, RooFit::Save() , RooFit::ExternalConstraints(*this->getWorkspace()->set(constraintName)), RooFit::Extended(kTRUE));
+    RooFitResult* result  = pdf->fitTo( *dataToFit, RooFit::Save() , RooFit::ExternalConstraints(*getWorkspace()->set(constraintName)), RooFit::Extended(kTRUE));
     // RooFitResult* result  = pdfBkg->fitTo( *dataToFit, RooFit::Save() , RooFit::ExternalConstraints(*this->getWorkspace()->set(constraintName)), RooFit::Extended(kTRUE));
     RooMsgService::instance().setSilentMode(kFALSE);
     RooMsgService::instance().setGlobalKillBelow(INFO);
     this->fitStatus = result->status();
     // RooAbsReal* nll_bkg = pdf->createNLL(*dataToFit, RooFit::Extended(kTRUE));
     // RooAbsReal* nll_bkg = pdfBkg->createNLL(*dataToFit, RooFit::Extended(kTRUE));
-    RooAbsReal* nll_bkg = pdf->createNLL(*dataToFit, RooFit::Extended(kTRUE), RooFit::ExternalConstraints(*this->getWorkspace()->set(constraintName)));
+    RooAbsReal* nll_bkg = pdf->createNLL(*dataToFit, RooFit::Extended(kTRUE), RooFit::ExternalConstraints(*getWorkspace()->set(constraintName)));
     // RooAbsReal* nll_bkg = pdfBkg->createNLL(*dataToFit, RooFit::Extended(kTRUE), RooFit::ExternalConstraints(*this->getWorkspace()->set(constraintName)));
     this->minNllBkg = nll_bkg->getVal();
 


### PR DESCRIPTION
In newer ROOT versions (at least > 6.14) we spotted a bug as reported in #177 that removed constraints from the likelihood in the fits with the result that the fits were not converging properly.

This is fixed now.