### PR TITLE
Datasets: use bkg if bkg pdf set, proper hChi2min2dplotting, debug plots

### DIFF
--- a/core/include/MethodDatasetsPluginScan.h
+++ b/core/include/MethodDatasetsPluginScan.h
@@ -36,7 +36,6 @@ public:
     inline  void        addFile(TString name) {inputFiles.push_back(name);};
 
     PDF_Datasets*           pdf;
-    bool                    drawPlots;
     bool                    explicitInputFile;
     std::vector<TString>    inputFiles;
     std::vector<double>     bootstrapPVals;

--- a/core/src/ControlPlots.cpp
+++ b/core/src/ControlPlots.cpp
@@ -10,6 +10,10 @@ ControlPlots::ControlPlots(ToyTree *tt)
 	ctrlPlotCuts = "statusFree==0 && statusScan==0";
 	// if ( arg->id!=-1 ) ctrlPlotCuts = ctrlPlotCuts && Form("BergerBoos_id==%i", arg->id);
 	if ( arg->id!=-1 ) ctrlPlotCuts = ctrlPlotCuts && Form("id==%i", arg->id);
+	if(t->GetEntries(ctrlPlotCuts)==0){
+		std::cout << "\nError in ControlPlots::ControlPlots(): Prob free fit or Prob scan fit have inappropriate fit result (fit status or cov qual). Cannot do control plots." << std::endl;
+		exit(1);
+	}
 }
 
 

--- a/core/src/MethodAbsScan.cpp
+++ b/core/src/MethodAbsScan.cpp
@@ -594,20 +594,24 @@ bool MethodAbsScan::interpolate(TH1F* h, int i, float y, float central, bool upp
 	TF1 *f1 = new TF1("f1", "pol2", h->GetBinCenter(i-2), h->GetBinCenter(i+2));
 	g->Fit("f1", "q");    // fit linear to get decent start parameters
 	g->Fit("f1", "qf+");  // refit with minuit to get more correct errors (TGraph fit errors bug)
-	float p[3], e[3];
+	double p[3], e[3];
 	for ( int ii=0; ii<3; ii++ )
 	{
 		p[ii] = f1->GetParameter(ii);
 		e[ii] = f1->GetParError(ii);
 	}
 
-	float sol0 = pq(p[0], p[1], p[2], y, 0);
-	float sol1 = pq(p[0], p[1], p[2], y, 1);
+	double sol0 = pq(p[0], p[1], p[2], y, 0);
+	double sol1 = pq(p[0], p[1], p[2], y, 1);
 	// cout << upper << " ";
 	// printf("%f %f %f\n", central, sol0, sol1);
-	if(h->GetBinCenter(i-2) > sol0 || sol0 > h->GetBinCenter(i+2) || h->GetBinCenter(i-2) > sol1 || sol1 > h->GetBinCenter(i+2))
+	// std::cout << central << "\t" << sol0 << "\t" <<sol1 << std::endl;
+	if((h->GetBinCenter(i-2) > sol0 || sol0 > h->GetBinCenter(i+2) ) && (h->GetBinCenter(i-2) > sol1 || sol1 > h->GetBinCenter(i+2)))
 	{
-		if(arg->verbose || arg->debug) cout << "Polynomial interpolation out of bounds." << endl;
+		if(arg->verbose || arg->debug){
+			cout << "MethodAbsScan::interpolate(): Quadratic interpolation out of bounds [" << h->GetBinCenter(i-2) <<", " << h->GetBinCenter(i+2) << "]:"<< std::endl;
+			std::cout << "Solutions are "<< central << "(free fit result)\t" << sol0 << "(bound solution 0) \t" <<sol1 << "(bound solution 1)." << std::endl;
+		}
 		return false;
 	}
 

--- a/core/src/MethodDatasetsPluginScan.cpp
+++ b/core/src/MethodDatasetsPluginScan.cpp
@@ -926,7 +926,7 @@ void MethodDatasetsPluginScan::readScan1dTrees(int runMin, int runMax, TString f
         h_all->SetYTitle("Valid toys");
         h_all->Draw();
         canvas->cd(2);
-        h_better->SetYTitle("Better toys than t_{measured}");
+        h_better->SetYTitle("Better toys than #Delta#chi^{2}_{data}");
         h_better->SetXTitle(w->var(scanVar1)->GetTitle());
         h_better->Draw();
         canvas->cd(3);

--- a/core/src/MethodDatasetsPluginScan.cpp
+++ b/core/src/MethodDatasetsPluginScan.cpp
@@ -719,8 +719,8 @@ void MethodDatasetsPluginScan::readScan1dTrees(int runMin, int runMax, TString f
             leg->AddEntry(bkg_pvals_clb,"CLb","L");
             leg->Draw("same");
             std::string pvalue_outstream;
-    		pvalue_outstream ="p_values" + std::to_string(i) + ".pdf";
-            canvasdebug->SaveAs(pvalue_outstream.c_str());
+    		pvalue_outstream ="p_values" + std::to_string(i);
+            savePlot(canvasdebug, pvalue_outstream.c_str());
         }
 
         std::vector<double> probs  = {TMath::Prob(4,1)/2., TMath::Prob(1,1)/2., 0.5, 1.-(TMath::Prob(1,1)/2.), 1.-(TMath::Prob(4,1)/2.) };
@@ -1322,6 +1322,8 @@ int MethodDatasetsPluginScan::scan1d(int nRun)
 			// set dataset back
 			if (arg->debug) cout << "Setting toy back as data " << tempData << endl;
 			this->pdf->setToyData( tempData );
+            // restore MinNllScan to value from 2. (not take from 2.5) for more correct error messages
+            pdf->setMinNllScan(toyTree.chi2minToy/2.);
 
             // Fit
             pdf->setFitStrategy(0);

--- a/core/src/MethodDatasetsPluginScan.cpp
+++ b/core/src/MethodDatasetsPluginScan.cpp
@@ -975,7 +975,8 @@ int MethodDatasetsPluginScan::scan1d(int nRun)
     }
     for ( int j = 0; j < nActualToys; j++ ) {
         // std::cout << "Toy " << j << std::endl;
-      if(pdf->getBkgPdf()){
+      // if(pdf->getBkgPdf())
+      {
         Utils::setParameters(w,dataBkgFitResult); //set parameters to bkg fit so the generation always starts at the same value
         // pdf->printParameters();
         pdf->generateBkgToys(0,arg->var[0]);

--- a/core/src/MethodDatasetsPluginScan.cpp
+++ b/core/src/MethodDatasetsPluginScan.cpp
@@ -29,9 +29,9 @@
 MethodDatasetsPluginScan::MethodDatasetsPluginScan(MethodProbScan* probScan, PDF_Datasets* PDF, OptParser* opt):
     MethodPluginScan(probScan, PDF, opt),
     pdf                 (PDF),
-    drawPlots           (arg->controlplots),
     explicitInputFile   (false)
 {
+    drawPlots=arg->controlplot;
     chi2minGlobalFound = true; // the free fit to data must be done and must be saved to the workspace before gammacombo is even called
     methodName = "DatasetsPlugin";
     w = PDF->getWorkspace();
@@ -847,7 +847,7 @@ void MethodDatasetsPluginScan::readScan1dTrees(int runMin, int runMax, TString f
         h_failed->GetXaxis()->SetLabelSize(0.06);
         h_failed->GetYaxis()->SetLabelSize(0.06);
         h_failed->SetLineWidth(2);
-        savePlot(biascanv, "failed_toys_plugin");
+        savePlot(canvas1, "failed_toys_plugin");
         TCanvas* can = newNoWarnTCanvas("can", "can");
         can->cd();
         gStyle->SetOptTitle(0);

--- a/core/src/MethodDatasetsPluginScan.cpp
+++ b/core/src/MethodDatasetsPluginScan.cpp
@@ -29,7 +29,7 @@
 MethodDatasetsPluginScan::MethodDatasetsPluginScan(MethodProbScan* probScan, PDF_Datasets* PDF, OptParser* opt):
     MethodPluginScan(probScan, PDF, opt),
     pdf                 (PDF),
-    drawPlots           (false),
+    drawPlots           (arg->controlplots),
     explicitInputFile   (false)
 {
     chi2minGlobalFound = true; // the free fit to data must be done and must be saved to the workspace before gammacombo is even called
@@ -691,7 +691,7 @@ void MethodDatasetsPluginScan::readScan1dTrees(int runMin, int runMax, TString f
         	cls_vals.push_back(cls_val);
         }
 
-        if (arg->debug || arg->controlplot ){
+        if (arg->debug || drawPlots ){
             TH1F *bkg_pvals_cls  = new TH1F(Form("bkg_clsvals_bin%d",i), "bkg cls p values", 50, -0.1, 1.1);
             bkg_pvals_cls->SetLineColor(1);
             bkg_pvals_cls->SetLineWidth(3);
@@ -797,10 +797,10 @@ void MethodDatasetsPluginScan::readScan1dTrees(int runMin, int runMax, TString f
         }
     }
 
-    if ( arg->controlplot ) makeControlPlots( sampledBValues, sampledSchi2Values );
-    if ( arg->controlplot ) makeControlPlotsBias( sampledBiasValues );
+    if ( drawPlots ) makeControlPlots( sampledBValues, sampledSchi2Values );
+    if ( drawPlots ) makeControlPlotsBias( sampledBiasValues );
 
-    if ( arg->controlplot ){
+    if ( drawPlots ){
         TCanvas *biascanv = newNoWarnTCanvas("biascanv", "biascanv");
         biascanv->SetRightMargin(0.11);
         h_sig_bkgtoys->GetXaxis()->SetTitle("POI residual for bkg-only toys");
@@ -823,7 +823,7 @@ void MethodDatasetsPluginScan::readScan1dTrees(int runMin, int runMax, TString f
         leg->Draw("same");
         savePlot(biascanv, "bkg-only_toyfit");
         hCLb->Draw("PE");
-        hCLb->GetXaxis()->SetTitle("POI value");
+        hCLb->GetXaxis()->SetTitle(w->var(scanVar1)->GetTitle());
         hCLb->GetYaxis()->SetTitle("CL_{b}");
         hCLb->GetXaxis()->SetTitleSize(0.06);
         hCLb->GetYaxis()->SetTitleSize(0.06);
@@ -839,6 +839,15 @@ void MethodDatasetsPluginScan::readScan1dTrees(int runMin, int runMax, TString f
         bkg_pvals->SetXTitle("bkg-only p value");
         bkg_pvals->Draw();
         savePlot(canvas1,"bkg_only_pvalues");
+        h_failed->Draw("PE");
+        h_failed->GetXaxis()->SetTitle(w->var(scanVar1)->GetTitle());
+        h_failed->GetYaxis()->SetTitle("N_{failed}");
+        h_failed->GetXaxis()->SetTitleSize(0.06);
+        h_failed->GetYaxis()->SetTitleSize(0.06);
+        h_failed->GetXaxis()->SetLabelSize(0.06);
+        h_failed->GetYaxis()->SetLabelSize(0.06);
+        h_failed->SetLineWidth(2);
+        savePlot(biascanv, "failed_toys_plugin");
         TCanvas* can = newNoWarnTCanvas("can", "can");
         can->cd();
         gStyle->SetOptTitle(0);
@@ -868,6 +877,8 @@ void MethodDatasetsPluginScan::readScan1dTrees(int runMin, int runMax, TString f
         h_background->SetXTitle("h_bkg");
         h_background->SetYTitle("fraction of neg. test stat toys");
         h_background->Draw();
+
+
     }
     // goodness-of-fit
 

--- a/core/src/MethodDatasetsProbScan.cpp
+++ b/core/src/MethodDatasetsProbScan.cpp
@@ -166,8 +166,7 @@ void MethodDatasetsProbScan::initScan() {
     chi2minGlobal = 2 * pdf->getMinNll();
     std::cout << "=============== Global minimum (2*-Log(Likelihood)) is: 2*" << globalMin->minNll() << " = " << chi2minGlobal << endl;
     // background only
-    if ( pdf->getBkgPdf() )
-    {
+    // if ( !pdf->getBkgPdf() ) 
       bkgOnlyFitResult = pdf->fitBkg(pdf->getData(), arg->var[0]); // fit on data w/ bkg only hypoth
       assert(bkgOnlyFitResult);
       bkgOnlyFitResult->SetName("bkgOnlyFitResult");
@@ -181,22 +180,21 @@ void MethodDatasetsProbScan::initScan() {
           chi2minBkg = chi2minGlobal;
           std::cout << "=============== New bkg minimum (2*-Log(Likelihood)) is: " << chi2minBkg << endl;
       }
-    }
-    else if ( arg->cls.size()!=0 ){
-        std::cout << "**************************************************************************************************************************************" << std::endl;
-        std::cout << "WARNING: No Bkg PDF is given! Will calculate CLs method by assuming the bkgchi2 to be the chi2 of the first bin." << std::endl;
-        std::cout << "WARNING: This is only an approximate solution and MIGHT EVEN BE WRONG, if the first bin does not represent the background expectation!" << std::endl;
-        std::cout << "**************************************************************************************************************************************" << std::endl;
+    // else if ( arg->cls.size()!=0 ){
+    //     std::cout << "**************************************************************************************************************************************" << std::endl;
+    //     std::cout << "WARNING: No Bkg PDF is given! Will calculate CLs method by assuming the bkgchi2 to be the chi2 of the first bin." << std::endl;
+    //     std::cout << "WARNING: This is only an approximate solution and MIGHT EVEN BE WRONG, if the first bin does not represent the background expectation!" << std::endl;
+    //     std::cout << "**************************************************************************************************************************************" << std::endl;
 
-        w->var(scanVar1)->setVal(min1);
-        w->var(scanVar1)->setConstant(true);
-        bkgOnlyFitResult = loadAndFit(pdf); // fit on data w/ bkg only hypoth
-        assert(bkgOnlyFitResult);
-        // chi2minBkg = 2 * bkgOnlyFitResult->minNll();
-        chi2minBkg = 2 * pdf->getMinNll();
-        std::cout << "=============== Bkg minimum (2*-Log(Likelihood)) is: 2*" << bkgOnlyFitResult->minNll() << " = " << chi2minBkg << endl;
-        w->var(scanVar1)->setConstant(false);
-    }
+    //     w->var(scanVar1)->setVal(min1);
+    //     w->var(scanVar1)->setConstant(true);
+    //     bkgOnlyFitResult = loadAndFit(pdf); // fit on data w/ bkg only hypoth
+    //     assert(bkgOnlyFitResult);
+    //     // chi2minBkg = 2 * bkgOnlyFitResult->minNll();
+    //     chi2minBkg = 2 * pdf->getMinNll();
+    //     std::cout << "=============== Bkg minimum (2*-Log(Likelihood)) is: 2*" << bkgOnlyFitResult->minNll() << " = " << chi2minBkg << endl;
+    //     w->var(scanVar1)->setConstant(false);
+    // }
 
 
     if (arg->debug) {

--- a/core/src/MethodDatasetsProbScan.cpp
+++ b/core/src/MethodDatasetsProbScan.cpp
@@ -722,11 +722,12 @@ int MethodDatasetsProbScan::scan2d()
                         if ( arg->verbose ) cout << "MethodDatasetsProbScan::scan2d() : WARNING : '" << title << "' new global minimum found! chi2minGlobal="
                                                             << chi2minGlobal << " chi2minScan=" << chi2minScan << endl;
                     }
+                    double deltaChi2_min = chi2minScan-chi2minGlobal;
                     chi2minGlobal = chi2minScan;
                     // recompute previous 1-CL values
                     for ( int k=1; k<=hCL2d->GetNbinsX(); k++ )
                         for ( int l=1; l<=hCL2d->GetNbinsY(); l++ ){
-                            hCL2d->SetBinContent(k, l, TMath::Prob(hChi2min2d->GetBinContent(k,l)-chi2minGlobal, ndof));
+                            hCL2d->SetBinContent(k, l, TMath::Prob(hChi2min2d->GetBinContent(k,l)-deltaChi2_min, ndof));
                             hCLs2d->SetBinContent(k, l, TMath::Prob(hChi2min2d->GetBinContent(k,l)-chi2minBkg, ndof));
                         }
                 }
@@ -747,7 +748,7 @@ int MethodDatasetsProbScan::scan2d()
                     hCL2d->SetBinContent(i, j, oneMinusCL);
                     double cls_pval = chi2minScan > chi2minBkg ? chi2minScan - chi2minBkg : 0.;
                     hCLs2d->SetBinContent(i, j, TMath::Prob(cls_pval, ndof));
-                    hChi2min2d->SetBinContent(i, j, chi2minScan);
+                    hChi2min2d->SetBinContent(i, j, deltaChi2);
                     hDbgChi2min2d->SetBinContent(i, j, chi2minScan);
                     curveResults2d[i-1][j-1] = r;
                 }
@@ -851,20 +852,24 @@ void MethodDatasetsProbScan::plotFitRes(TString fName) {
     // data invisible for norm
     w->data(pdf->getDataName())->plotOn( plot, Invisible() );
     // bkg pdf
+    if ( !bkgOnlyFitResult ) {
+      cout << "MethodDatasetsProbScan::plotFitRes() : ERROR : bkgOnlyFitResult is NULL" << endl;
+      exit(1);
+    }
+    setParameters(w, bkgOnlyFitResult);
+    // if ( !w->pdf(pdf->getBkgPdfName()) ) {
+    //   cout << "MethodDatasetsProbScan::plotFitRes() : ERROR : No background pdf " << pdf->getBkgPdfName() << " found in workspace" << endl;
+    //   exit(1);
+    // }
     if( pdf->getBkgPdf() ){
-        if ( !bkgOnlyFitResult ) {
-          cout << "MethodDatasetsProbScan::plotFitRes() : ERROR : bkgOnlyFitResult is NULL" << endl;
-          exit(1);
-        }
-        setParameters(w, bkgOnlyFitResult);
-        if ( !w->pdf(pdf->getBkgPdfName()) ) {
-          cout << "MethodDatasetsProbScan::plotFitRes() : ERROR : No background pdf " << pdf->getBkgPdfName() << " found in workspace" << endl;
-          exit(1);
-        }
         w->pdf(pdf->getBkgPdfName())->plotOn( plot, LineColor(kRed) );
         leg->AddEntry( plot->getObject(plot->numItems()-1), "Background Only Fit", "L");
     }
-    else cout << "MethodDatasetsProbScan::plotFitRes() : WARNING : No background pdf is given. Will only plot S+B hypothesis." << std::endl;
+    else{
+        cout << "MethodDatasetsProbScan::plotFitRes() : WARNING : No background pdf is given. Will plot S+B hypothesis with S=0." << std::endl;
+        w->pdf(pdf->getPdfName())->plotOn( plot, LineColor(kRed) );
+        leg->AddEntry( plot->getObject(plot->numItems()-1), "Background Only Fit", "L");
+    }
     // free fit
     if ( !globalMin ) {
       cout << "MethodDatasetsProbScan::plotFitRes() : ERROR : globalMin is NULL" << endl;

--- a/core/src/MethodPluginScan.cpp
+++ b/core/src/MethodPluginScan.cpp
@@ -1178,7 +1178,7 @@ TH1F* MethodPluginScan::analyseToys(ToyTree* t, int id)
           leg->AddEntry(bkg_pvals_clsb,"CLs+b","L");
           leg->AddEntry(bkg_pvals_clb,"CLb","L");
           leg->Draw("same");
-          savePlot(canvasdebug,Form("p_values%d",i));
+          savePlot(canvasdebug,TString(Form("p_values%d",i))+"_"+scanVar1);
         }
 
 
@@ -1583,7 +1583,7 @@ void MethodPluginScan::makeControlPlotsCLs(map<int, vector<double> > bVals, map<
     leg->AddEntry(lD,"Data","L");
     leg->Draw("same");
     c->SetLogy();
-    savePlot(c,Form("cls_testStatControlPlot_p%d",i) );
+    savePlot(c,TString(Form("cls_testStatControlPlot_p%d",i))+"_"+scanVar1 );
   }
 
   TCanvas *c = newNoWarnTCanvas( "cls_ctr", "CLs Control" );
@@ -1619,7 +1619,7 @@ void MethodPluginScan::makeControlPlotsCLs(map<int, vector<double> > bVals, map<
   hCLsExp->Draw("Lsame");
   hCLsFreq->Draw("Lsame");
 
-  savePlot(c, "cls_ControlPlot");
+  savePlot(c, "cls_ControlPlot_"+scanVar1);
 
 }
 

--- a/core/src/OneMinusClPlot.cpp
+++ b/core/src/OneMinusClPlot.cpp
@@ -425,31 +425,31 @@ void OneMinusClPlot::scan1dCLsPlot(MethodAbsScan *s, bool smooth, bool obsError)
 
     //alternative smoothing option, needs more fiddling
     // gExp    = (TGraph*)smoother->SmoothKern( gExpRaw   ,"normal",hExp->GetBinWidth(1)*4)->Clone("gExp");
-    gErr1Up = (TGraph*)smoother->SmoothKern( gErr1UpRaw,"normal",hErr1Up->GetBinWidth(1)*2)->Clone("gErr1Up");
+    gErr1Up = (TGraph*)smoother->SmoothKern( gErr1UpRaw,"normal",hErr1Up->GetBinWidth(1)*2, hErr1Up->GetNbinsX())->Clone("gErr1Up");
     // gErr1Dn = (TGraph*)smoother->SmoothKern( gErr1DnRaw,"normal",hErr1Dn->GetBinWidth(1)*4)->Clone("gErr1Dn");
-    gErr2Up = (TGraph*)smoother->SmoothKern( gErr2UpRaw,"normal",hErr2Up->GetBinWidth(1)*2)->Clone("gErr2Up");
+    gErr2Up = (TGraph*)smoother->SmoothKern( gErr2UpRaw,"normal",hErr2Up->GetBinWidth(1)*2, hErr1Up->GetNbinsX())->Clone("gErr2Up");
     // gErr2Dn = (TGraph*)smoother->SmoothKern( gErr2DnRaw,"normal",hErr2Dn->GetBinWidth(1)*4)->Clone("gErr2Dn");
 
     // //make sure the CLs=1 points do NOT get smoothed away
 
-    // double *xvals = gExp->GetX();
-    // double *xvalsRaw = gExpRaw->GetX();
-    // double *yvalsRawExp = gExpRaw->GetY();
-    // double *yvalsRawExpErr1Up = gErr1UpRaw->GetY();
-    // double *yvalsRawExpErr2Up = gErr2UpRaw->GetY();
+    double *xvals = gExp->GetX();
+    double *xvalsRaw = gExpRaw->GetX();
+    double *yvalsRawExp = gExpRaw->GetY();
+    double *yvalsRawExpErr1Up = gErr1UpRaw->GetY();
+    double *yvalsRawExpErr2Up = gErr2UpRaw->GetY();
 
-    // for (int i=0; i<gExp->GetN(); i++){
-    // 	std::cout << xvalsRaw[i] << "\t" <<xvals[i] << std::endl;
-    // 	if(yvalsRawExp[i]>0.99){
-    // 		gExp->SetPoint(i,xvals[i], 1.0);
-    // 	}
-    // 	if(yvalsRawExpErr1Up[i]>0.99){
-    // 		gErr1Up->SetPoint(i,xvals[i], 1.0);
-    // 	}
-    // 	if(yvalsRawExpErr2Up[i]>0.99){
-    // 		gErr2Up->SetPoint(i,xvals[i], 1.0);
-    // 	}
-    // }
+    for (int i=0; i<gExp->GetN(); i++){
+    	std::cout << xvalsRaw[i] << "\t" <<xvals[i] << std::endl;
+    	// if(yvalsRawExp[i]>0.99){
+    	// 	gExp->SetPoint(i,xvals[i], 1.0);
+    	// }
+    	if(yvalsRawExpErr1Up[i]>0.99){
+    		gErr1Up->SetPoint(i,xvals[i], 1.0);
+    	}
+    	if(yvalsRawExpErr2Up[i]>0.99){
+    		gErr2Up->SetPoint(i,xvals[i], 1.0);
+    	}
+    }
 
     // fix point 0 to CLs=1 for all expected curves
 

--- a/core/src/OneMinusClPlot.cpp
+++ b/core/src/OneMinusClPlot.cpp
@@ -439,7 +439,7 @@ void OneMinusClPlot::scan1dCLsPlot(MethodAbsScan *s, bool smooth, bool obsError)
     double *yvalsRawExpErr2Up = gErr2UpRaw->GetY();
 
     for (int i=0; i<gExp->GetN(); i++){
-    	std::cout << xvalsRaw[i] << "\t" <<xvals[i] << std::endl;
+    	// std::cout << xvalsRaw[i] << "\t" <<xvals[i] << std::endl;
     	// if(yvalsRawExp[i]>0.99){
     	// 	gExp->SetPoint(i,xvals[i], 1.0);
     	// }

--- a/core/src/PDF_Datasets.cpp
+++ b/core/src/PDF_Datasets.cpp
@@ -161,6 +161,7 @@ void PDF_Datasets::initPDF(const TString& name) {
 };
 
 void PDF_Datasets::initBkgPDF(const TString& name) {
+    std::cout << "PDF_Datasets::initBkgPDF() currently useless, as the Bkg pdf is taken as the full pdf with scanvar=0" << std::endl;
     if (isBkgPdfSet) {
         std::cout << "ERROR in PDF_Datasets::initBkgPDF -- Bkg PDF already set" << std::endl;
         exit(EXIT_FAILURE);
@@ -326,12 +327,13 @@ RooFitResult* PDF_Datasets::fitBkg(RooDataSet* dataToFit, TString signalvar) {
         std::cout << "Other names can be passed via PDF_Datasets::initConstraints" << std::endl;
         exit(EXIT_FAILURE);
     }
+    // if (!pdfBkg)
+    // {
+    //     std::cout << "WARNING in PDF_Datasets::fitBkg -- No background PDF given!" << std::endl;
+    //     // exit(EXIT_FAILURE);
+    // }
+    // std::cout << "WARNING in PDF_Datasets::fitBkg -- Fitting bkg model as sig+bkg model with " << signalvar << " to zero!" << std::endl;
 
-    if (!pdfBkg)
-    {
-        std::cout << "ERROR in PDF_Datasets::fitBkg -- No background PDF given!" << std::endl;
-        exit(EXIT_FAILURE);
-    }
     double parvalue = getWorkspace()->var(signalvar)->getVal();
     bool isconst = getWorkspace()->var(signalvar)->isConstant();
     getWorkspace()->var(signalvar)->setVal(0.0);
@@ -380,7 +382,13 @@ void   PDF_Datasets::generateBkgToys(int SeedShift, TString signalvar) {
 
     initializeRandomGenerator(SeedShift);
 
-    if(isBkgPdfSet){
+    // if(!isBkgPdfSet){
+    //     std::cout << "WRANING in PDF_Datasets::generateBkgToys: No bkg pdf given." << std::endl;
+    //     // exit(EXIT_FAILURE);
+    // }
+    // std::cout << "WARNING in PDF_Datasets::generateBkgToys -- Fitting bkg model as sig+bkg model with " << signalvar << " to zero!" << std::endl;
+    // if(isBkgPdfSet)
+    {
         double parvalue = getWorkspace()->var(signalvar)->getVal();
         bool isconst = getWorkspace()->var(signalvar)->isConstant();
         getWorkspace()->var(signalvar)->setVal(0.0);
@@ -391,10 +399,6 @@ void   PDF_Datasets::generateBkgToys(int SeedShift, TString signalvar) {
         getWorkspace()->var(signalvar)->setVal(parvalue);
         getWorkspace()->var(signalvar)->setConstant(isconst);    
         this->toyBkgObservables  = toys;
-    }
-    else{
-        std::cerr << "Error in PDF_Datasets::generateBkgToys: No bkg pdf given." << std::endl;
-        exit(EXIT_FAILURE);
     }
 };
 

--- a/core/src/PDF_Datasets.cpp
+++ b/core/src/PDF_Datasets.cpp
@@ -161,7 +161,7 @@ void PDF_Datasets::initPDF(const TString& name) {
 };
 
 void PDF_Datasets::initBkgPDF(const TString& name) {
-    std::cout << "PDF_Datasets::initBkgPDF() currently useless, as the Bkg pdf is taken as the full pdf with scanvar=0" << std::endl;
+    // std::cout << "PDF_Datasets::initBkgPDF() currently useless, as the Bkg pdf is taken as the full pdf with scanvar=0" << std::endl;
     if (isBkgPdfSet) {
         std::cout << "ERROR in PDF_Datasets::initBkgPDF -- Bkg PDF already set" << std::endl;
         exit(EXIT_FAILURE);

--- a/scripts/run_ci_tests.py
+++ b/scripts/run_ci_tests.py
@@ -53,7 +53,7 @@ def check_dsets_stdout_cls( logf ):
 def check_dsets_dat( datf ):
   f = open(datf)
   for line in f.readlines():
-    if line.startswith('Nbkg'):                assert('4990.208984   -71.760254    71.760254' in line)
+    if line.startswith('Nbkg'):                assert('4990.20' in line and '-71.76' in line and '71.76' in line)
     if line.startswith('branchingRatio'):      assert('   0.000000    -0.000000     0.000000' in line)
     if line.startswith('exponent'):            assert('  -0.000977    -0.000027     0.000027' in line)
     if line.startswith('mean'):                assert('5370.000000     1.000000    -1.000000' in line)

--- a/tutorial/src/PDF_Gaus.cpp
+++ b/tutorial/src/PDF_Gaus.cpp
@@ -30,7 +30,7 @@ void PDF_Gaus::initParameters()
 	ParametersTutorial p;
 	parameters = new RooArgList("parameters");
 	parameters->add(*(p.get("a_gaus")));
-	parameters->add(*(p.get("b_gaus")));
+	// parameters->add(*(p.get("b_gaus")));
 }
 
 

--- a/tutorial/src/PDF_Gaus.cpp
+++ b/tutorial/src/PDF_Gaus.cpp
@@ -30,7 +30,6 @@ void PDF_Gaus::initParameters()
 	ParametersTutorial p;
 	parameters = new RooArgList("parameters");
 	parameters->add(*(p.get("a_gaus")));
-	// parameters->add(*(p.get("b_gaus")));
 }
 
 


### PR DESCRIPTION
A few fixes for the datasets part:
* If a bkg pdf is set use bkg pdf for CLs method (before: define bkg pdf as best fit with `scanVar=0`, this is still the backup solution if no bkg pdf is set)
* Closes #122: Redefine hChi2min2d as `chi2minScan - chi2minGlobal`. This is then similar to what happens in the combiner part of GammaCombo, where the normalisation to the likelihood minimum is done already in the `Utils::fitToMin` etc. methods
* Closes #66: Actually activate the quadratic interpolation for the calculation of the interval boundary, which was not used due to a bug before.
