### PR TITLE
Error bars for `hCLsExp`

### DIFF
--- a/core/src/MethodDatasetsPluginScan.cpp
+++ b/core/src/MethodDatasetsPluginScan.cpp
@@ -763,6 +763,7 @@ void MethodDatasetsPluginScan::readScan1dTrees(int runMin, int runMax, TString f
 
         // //ideal method, but prone to fluctuations
         hCLsExp->SetBinContent   ( i, TMath::Min( quantiles_cls[2] , 1.) );
+        hCLsExp->SetBinError   ( i, sq((1.-TMath::Min( quantiles_cls[2] , 1.))*TMath::Min( quantiles_cls[2] , 1.)/sampledBValues[i].size()) );        
         hCLsErr1Up->SetBinContent( i, TMath::Min( quantiles_cls[3] , 1.) );
         hCLsErr1Dn->SetBinContent( i, TMath::Min( quantiles_cls[1] , 1.) );
         hCLsErr2Up->SetBinContent( i, TMath::Min( quantiles_cls[4] , 1.) );

--- a/core/src/MethodDatasetsPluginScan.cpp
+++ b/core/src/MethodDatasetsPluginScan.cpp
@@ -763,7 +763,7 @@ void MethodDatasetsPluginScan::readScan1dTrees(int runMin, int runMax, TString f
 
         // //ideal method, but prone to fluctuations
         hCLsExp->SetBinContent   ( i, TMath::Min( quantiles_cls[2] , 1.) );
-        hCLsExp->SetBinError   ( i, sq((1.-TMath::Min( quantiles_cls[2] , 1.))*TMath::Min( quantiles_cls[2] , 1.)/sampledBValues[i].size()) );        
+        hCLsExp->SetBinError   ( i, sqrt((1.-TMath::Min( quantiles_cls[2] , 1.))*TMath::Min( quantiles_cls[2] , 1.)/sampledBValues[i].size()) );        
         hCLsErr1Up->SetBinContent( i, TMath::Min( quantiles_cls[3] , 1.) );
         hCLsErr1Dn->SetBinContent( i, TMath::Min( quantiles_cls[1] , 1.) );
         hCLsErr2Up->SetBinContent( i, TMath::Min( quantiles_cls[4] , 1.) );

--- a/core/src/MethodPluginScan.cpp
+++ b/core/src/MethodPluginScan.cpp
@@ -1178,7 +1178,7 @@ TH1F* MethodPluginScan::analyseToys(ToyTree* t, int id)
           leg->AddEntry(bkg_pvals_clsb,"CLs+b","L");
           leg->AddEntry(bkg_pvals_clb,"CLb","L");
           leg->Draw("same");
-          savePlot(canvasdebug,Form("p_values%d",i));
+          savePlot(canvasdebug,TString(Form("p_values%d",i))+"_"+scanVar1);
         }
 
 
@@ -1583,7 +1583,7 @@ void MethodPluginScan::makeControlPlotsCLs(map<int, vector<double> > bVals, map<
     leg->AddEntry(lD,"Data","L");
     leg->Draw("same");
     c->SetLogy();
-    savePlot(c,Form("cls_testStatControlPlot_p%d",i) );
+    savePlot(c,TString(Form("cls_testStatControlPlot_p%d",i))+"_"+scanVar1 );
   }
 
   TCanvas *c = newNoWarnTCanvas( "cls_ctr", "CLs Control" );
@@ -1619,7 +1619,7 @@ void MethodPluginScan::makeControlPlotsCLs(map<int, vector<double> > bVals, map<
   hCLsExp->Draw("Lsame");
   hCLsFreq->Draw("Lsame");
 
-  savePlot(c, "cls_ControlPlot");
+  savePlot(c, "cls_ControlPlot_"+scanVar1);
 
 }
 

--- a/core/src/MethodPluginScan.cpp
+++ b/core/src/MethodPluginScan.cpp
@@ -1216,6 +1216,7 @@ TH1F* MethodPluginScan::analyseToys(ToyTree* t, int id)
 
         // //ideal method, but prone to fluctuations
         hCLsExp->SetBinContent   ( i, TMath::Min( quantiles_cls[2] , 1.) );
+        hCLsExp->SetBinError   ( i, sq((1.-TMath::Min( quantiles_cls[2] , 1.))*TMath::Min( quantiles_cls[2] , 1.)/sampledBValues[i].size()) );        
         hCLsErr1Up->SetBinContent( i, TMath::Min( quantiles_cls[3] , 1.) );
         hCLsErr1Dn->SetBinContent( i, TMath::Min( quantiles_cls[1] , 1.) );
         hCLsErr2Up->SetBinContent( i, TMath::Min( quantiles_cls[4] , 1.) );

--- a/core/src/MethodPluginScan.cpp
+++ b/core/src/MethodPluginScan.cpp
@@ -1216,7 +1216,7 @@ TH1F* MethodPluginScan::analyseToys(ToyTree* t, int id)
 
         // //ideal method, but prone to fluctuations
         hCLsExp->SetBinContent   ( i, TMath::Min( quantiles_cls[2] , 1.) );
-        hCLsExp->SetBinError   ( i, sq((1.-TMath::Min( quantiles_cls[2] , 1.))*TMath::Min( quantiles_cls[2] , 1.)/sampledBValues[i].size()) );        
+        hCLsExp->SetBinError   ( i, sqrt((1.-TMath::Min( quantiles_cls[2] , 1.))*TMath::Min( quantiles_cls[2] , 1.)/sampledBValues[i].size()) );        
         hCLsErr1Up->SetBinContent( i, TMath::Min( quantiles_cls[3] , 1.) );
         hCLsErr1Dn->SetBinContent( i, TMath::Min( quantiles_cls[1] , 1.) );
         hCLsErr2Up->SetBinContent( i, TMath::Min( quantiles_cls[4] , 1.) );

--- a/scripts/run_ci_tests.py
+++ b/scripts/run_ci_tests.py
@@ -109,7 +109,7 @@ def check_comb_plugin_gen():
   return True
 
 def check_comb_plugin_run():
-  cmd  = 'bin/tutorial -c 5 --var a_gaus -a plugin --ntoys 5 --ps 1 --grouppos def:0.8'
+  cmd  = 'bin/tutorial -c 5 --var a_gaus -a plugin --ps 1 --grouppos def:0.8 --controlplots'
   outn = 'comb_plugin_run'
   os.system('%s > ci_logs/%s.log 2>&1'%(cmd,outn))
   check_comb_stdout('ci_logs/%s.log'%outn)
@@ -173,7 +173,7 @@ def check_dsets_plugin_gen():
 
 def check_dsets_plugin_run():
   assert( os.path.exists(os.path.join(os.getcwd(),'workspace.root')) )
-  cmd  = 'bin/tutorial_dataset --var branchingRatio --scanrange 0:5.e-7 -a plugin --ps 1 --npoints 20 --npointstoy 20'
+  cmd  = 'bin/tutorial_dataset --var branchingRatio --scanrange 0:5.e-7 -a plugin --ps 1 --npoints 20 --npointstoy 20 --controlplots'
   outn = 'dsets_plugin_run'
   os.system('%s > ci_logs/%s.log 2>&1'%(cmd,outn))
   check_dsets_stdout('ci_logs/%s.log'%outn)


### PR DESCRIPTION
adding error bars to the `hCLsExp` to improve the interpolation for the expected limit calculations.
Fixes #210 