### PR TITLE
Incorporate errors of confidence curves into boundary interpolation

### DIFF
--- a/core/src/MethodAbsScan.cpp
+++ b/core/src/MethodAbsScan.cpp
@@ -547,6 +547,12 @@ bool MethodAbsScan::interpolate(TH1F* h, int i, float y, float central, bool upp
 	if ( i > h->GetNbinsX()-2 ) return false;
 	if ( i < 3 ) return false;
 
+	if(methodName.Contains("Prob")){
+		for (int k=0;k<h->GetNbinsX();k++){
+			h->SetBinError(k+1,0.);
+		}
+	}
+
 	// compute pol2 fit interpolation
 	TGraphErrors *g = new TGraphErrors(3);
 	g->SetPoint(0, h->GetBinCenter(i-1), h->GetBinContent(i-1));
@@ -602,7 +608,7 @@ bool MethodAbsScan::interpolate(TH1F* h, int i, float y, float central, bool upp
 	double sol1 = pq(p[0], p[1], p[2], y, 1);
 	// cout << upper << " ";
 	// printf("%f %f %f\n", central, sol0, sol1);
-	// std::cout << central << "\t" << sol0 << "\t" <<sol1 << std::endl;
+	std::cout << central << "\t" << sol0 << "\t" <<sol1 << std::endl;
 
 	// debug: show fitted 1-CL histogram
 	if ( arg->controlplot)

--- a/core/src/MethodAbsScan.cpp
+++ b/core/src/MethodAbsScan.cpp
@@ -547,6 +547,7 @@ bool MethodAbsScan::interpolate(TH1F* h, int i, float y, float central, bool upp
 	if ( i > h->GetNbinsX()-2 ) return false;
 	if ( i < 3 ) return false;
 
+	// if method Prob, don't interpolate (no proper error estimate)
 	if(methodName.Contains("Prob")){
 		for (int k=0;k<h->GetNbinsX();k++){
 			h->SetBinError(k+1,0.);

--- a/core/src/MethodDatasetsPluginScan.cpp
+++ b/core/src/MethodDatasetsPluginScan.cpp
@@ -20,10 +20,10 @@
 #include <algorithm>
 #include <ios>
 #include <iomanip>
-#include <boost/accumulators/accumulators.hpp>
-#include <boost/accumulators/statistics/stats.hpp>
-#include <boost/accumulators/statistics/mean.hpp>
-#include <boost/accumulators/statistics/variance.hpp>
+// #include <boost/accumulators/accumulators.hpp>
+// #include <boost/accumulators/statistics/stats.hpp>
+// #include <boost/accumulators/statistics/mean.hpp>
+// #include <boost/accumulators/statistics/variance.hpp>
 
 
 
@@ -804,16 +804,16 @@ void MethodDatasetsPluginScan::readScan1dTrees(int runMin, int runMax, TString f
         // // cout <<hCLsExp->GetBinContent(i)<<": " <<  boost::accumulators::mean(acc) << "\t" << sqrt(boost::accumulators::variance(acc)) << endl;
         // mederr_bootstrap->SetBinContent(i , sqrt(boost::accumulators::variance(acc)));
 
-        // std::cout << "non-parameric median errors for bin " << i << std::endl;
-        std::sort (cls_vals.begin(), cls_vals.begin()+cls_vals.size());
-        int k =0;
-        do{
-            k++;
-            // std::cout << "Binomial: " << TMath::BinomialI(0.5, cls_vals.size(), cls_vals.size()/2-k) - TMath::BinomialI(0.5, cls_vals.size(), cls_vals.size()/2+k) << std::endl;
-        // }while( ROOT::Math::binomial_cdf(cls_vals.size()/2+k,0.5, cls_vals.size()) - ROOT::Math::binomial_cdf(cls_vals.size()/2-k,0.5, cls_vals.size()) <=0.68);
-        }while(TMath::BetaIncomplete(0.5,cls_vals.size()/2-k+1, cls_vals.size()-(cls_vals.size()/2-k)) - TMath::BetaIncomplete(0.5,cls_vals.size()/2+k+1, cls_vals.size()-(cls_vals.size()/2+k))<=0.68);
+        // // std::cout << "non-parameric median errors for bin " << i << std::endl;
+        // std::sort (cls_vals.begin(), cls_vals.begin()+cls_vals.size());
+        // int k =0;
+        // do{
+        //     k++;
+        //     // std::cout << "Binomial: " << TMath::BinomialI(0.5, cls_vals.size(), cls_vals.size()/2-k) - TMath::BinomialI(0.5, cls_vals.size(), cls_vals.size()/2+k) << std::endl;
+        // // }while( ROOT::Math::binomial_cdf(cls_vals.size()/2+k,0.5, cls_vals.size()) - ROOT::Math::binomial_cdf(cls_vals.size()/2-k,0.5, cls_vals.size()) <=0.68);
+        // }while(TMath::BetaIncomplete(0.5,cls_vals.size()/2-k+1, cls_vals.size()-(cls_vals.size()/2-k)) - TMath::BetaIncomplete(0.5,cls_vals.size()/2+k+1, cls_vals.size()-(cls_vals.size()/2+k))<=0.68);
 
-        hCLsExp->SetBinError(i , (cls_vals[cls_vals.size()/2+k-1] - cls_vals[cls_vals.size()/2-k-1])/2.);
+        // hCLsExp->SetBinError(i , (cls_vals[cls_vals.size()/2+k-1] - cls_vals[cls_vals.size()/2-k-1])/2.);
 
         // double mederr_asymptotic_val = sqrt( probs[2]*( 1.-probs[2] ) / ( cls_vals.size()*bkg_pvals_cls->GetBinContent( bkg_pvals_cls->FindBin( TMath::Min( quantiles_cls[2], 1. ) ) ) / ( 1.0*bkg_pvals_cls->GetEntries()*bkg_pvals_cls->GetBinWidth(2) ) ) );
         // std::vector<double> low_high_median = {0.5 - mederr_asymptotic_val, 0.5 + mederr_asymptotic_val};

--- a/core/src/MethodPluginScan.cpp
+++ b/core/src/MethodPluginScan.cpp
@@ -1222,6 +1222,16 @@ TH1F* MethodPluginScan::analyseToys(ToyTree* t, int id)
         hCLsErr2Up->SetBinContent( i, TMath::Min( quantiles_cls[4] , 1.) );
         hCLsErr2Dn->SetBinContent( i, TMath::Min( quantiles_cls[0] , 1.) );
 
+        // std::cout << "non-parameric median errors for bin " << i << std::endl;
+        std::sort (cls_vals.begin(), cls_vals.begin()+cls_vals.size());
+        int k =0;
+        do{
+            k++;
+            // std::cout << "Binomial: " << TMath::BinomialI(0.5, cls_vals.size(), cls_vals.size()/2-k) - TMath::BinomialI(0.5, cls_vals.size(), cls_vals.size()/2+k) << std::endl;
+        // }while( ROOT::Math::binomial_cdf(cls_vals.size()/2+k,0.5, cls_vals.size()) - ROOT::Math::binomial_cdf(cls_vals.size()/2-k,0.5, cls_vals.size()) <=0.68);
+        }while(TMath::BetaIncomplete(0.5,cls_vals.size()/2-k+1, cls_vals.size()-(cls_vals.size()/2-k)) - TMath::BetaIncomplete(0.5,cls_vals.size()/2+k+1, cls_vals.size()-(cls_vals.size()/2+k))<=0.68);
+
+        hCLsExp->SetBinError(i , (cls_vals[cls_vals.size()/2+k-1] - cls_vals[cls_vals.size()/2-k-1])/2.);
     }
 
     if ( arg->controlplot && arg->cls.size()>0) makeControlPlotsCLs( sampledBValues, sampledSchi2Values );

--- a/core/src/MethodPluginScan.cpp
+++ b/core/src/MethodPluginScan.cpp
@@ -1223,15 +1223,15 @@ TH1F* MethodPluginScan::analyseToys(ToyTree* t, int id)
         hCLsErr2Dn->SetBinContent( i, TMath::Min( quantiles_cls[0] , 1.) );
 
         // std::cout << "non-parameric median errors for bin " << i << std::endl;
-        std::sort (cls_vals.begin(), cls_vals.begin()+cls_vals.size());
-        int k =0;
-        do{
-            k++;
-            // std::cout << "Binomial: " << TMath::BinomialI(0.5, cls_vals.size(), cls_vals.size()/2-k) - TMath::BinomialI(0.5, cls_vals.size(), cls_vals.size()/2+k) << std::endl;
-        // }while( ROOT::Math::binomial_cdf(cls_vals.size()/2+k,0.5, cls_vals.size()) - ROOT::Math::binomial_cdf(cls_vals.size()/2-k,0.5, cls_vals.size()) <=0.68);
-        }while(TMath::BetaIncomplete(0.5,cls_vals.size()/2-k+1, cls_vals.size()-(cls_vals.size()/2-k)) - TMath::BetaIncomplete(0.5,cls_vals.size()/2+k+1, cls_vals.size()-(cls_vals.size()/2+k))<=0.68);
+        // std::sort (cls_vals.begin(), cls_vals.begin()+cls_vals.size());
+        // int k =0;
+        // do{
+        //     k++;
+        //     // std::cout << "Binomial: " << TMath::BinomialI(0.5, cls_vals.size(), cls_vals.size()/2-k) - TMath::BinomialI(0.5, cls_vals.size(), cls_vals.size()/2+k) << std::endl;
+        // // }while( ROOT::Math::binomial_cdf(cls_vals.size()/2+k,0.5, cls_vals.size()) - ROOT::Math::binomial_cdf(cls_vals.size()/2-k,0.5, cls_vals.size()) <=0.68);
+        // }while(TMath::BetaIncomplete(0.5,cls_vals.size()/2-k+1, cls_vals.size()-(cls_vals.size()/2-k)) - TMath::BetaIncomplete(0.5,cls_vals.size()/2+k+1, cls_vals.size()-(cls_vals.size()/2+k))<=0.68);
 
-        hCLsExp->SetBinError(i , (cls_vals[cls_vals.size()/2+k-1] - cls_vals[cls_vals.size()/2-k-1])/2.);
+        // hCLsExp->SetBinError(i , (cls_vals[cls_vals.size()/2+k-1] - cls_vals[cls_vals.size()/2-k-1])/2.);
     }
 
     if ( arg->controlplot && arg->cls.size()>0) makeControlPlotsCLs( sampledBValues, sampledSchi2Values );


### PR DESCRIPTION
The p-values are known to only a given accuracy. The uncertainties on the p-values are now included in the interpolation fit to obtain the confidence interval boundaries. The effect should be very small.
Also several methods to obtain the error on the expected limit curve are exploited, but in the end the simple binomial error on the median cls value is chosen, because seems most robust and reliable.
The rest is commented.