### PR TITLE
equal treatment of s+b and b-only toys for negative test statistics

### DIFF
--- a/core/src/MethodAbsScan.cpp
+++ b/core/src/MethodAbsScan.cpp
@@ -609,7 +609,7 @@ bool MethodAbsScan::interpolate(TH1F* h, int i, float y, float central, bool upp
 	double sol1 = pq(p[0], p[1], p[2], y, 1);
 	// cout << upper << " ";
 	// printf("%f %f %f\n", central, sol0, sol1);
-	std::cout << central << "\t" << sol0 << "\t" <<sol1 << std::endl;
+	// std::cout << central << "\t" << sol0 << "\t" <<sol1 << std::endl;
 
 	// debug: show fitted 1-CL histogram
 	if ( arg->controlplot)

--- a/core/src/MethodAbsScan.cpp
+++ b/core/src/MethodAbsScan.cpp
@@ -547,6 +547,7 @@ bool MethodAbsScan::interpolate(TH1F* h, int i, float y, float central, bool upp
 	if ( i > h->GetNbinsX()-2 ) return false;
 	if ( i < 3 ) return false;
 
+	// if method Prob, don't interpolate (no proper error estimate)
 	if(methodName.Contains("Prob")){
 		for (int k=0;k<h->GetNbinsX();k++){
 			h->SetBinError(k+1,0.);

--- a/core/src/MethodDatasetsPluginScan.cpp
+++ b/core/src/MethodDatasetsPluginScan.cpp
@@ -612,7 +612,7 @@ void MethodDatasetsPluginScan::readScan1dTrees(int runMin, int runMax, TString f
         // chi2minBkgToy is the best fit at scanpoint of bkg-only toy
         if(b_teststat_toy<0&&b_teststat_toy>-1.e-6) b_teststat_toy=0.0;
 
-        if( !BadBkgFit ){
+        if( !BadBkgFit && b_teststat_toy>-1.e-6){
             if(hBin==2){
                 // std::cout << bkgTestStatVal << std::endl;
                 bkg_pvals->Fill(TMath::Prob(b_teststat_toy,1));

--- a/core/src/MethodDatasetsPluginScan.cpp
+++ b/core/src/MethodDatasetsPluginScan.cpp
@@ -626,6 +626,7 @@ void MethodDatasetsPluginScan::readScan1dTrees(int runMin, int runMax, TString f
 
         // use the unphysical events to estimate background (be careful with this,
         // at least inspect the control plots to judge if this can be at all reasonable)
+        // ToDo: is that really sensible? Currently only used for control plots and background is estimated in a dedicated way
         if ( valid && !inPhysicalRegion ) {
             h_background->Fill(t.scanpoint);
         }
@@ -644,7 +645,8 @@ void MethodDatasetsPluginScan::readScan1dTrees(int runMin, int runMax, TString f
     cout << "MethodDatasetsPluginScan::readScan1dTrees() : read an average of " << ((double)nentries - (double)nfailed) / (double)nPoints1d << " toys per scan point." << endl;
     cout << "MethodDatasetsPluginScan::readScan1dTrees() : fraction of failed toys: " << (double)nfailed / (double)nentries * 100. << "%." << endl;
     cout << "MethodDatasetsPluginScan::readScan1dTrees() : fraction of failed background toys: " << (double)nfailedbkg / (double)nentries * 100. << "%." << endl;
-    cout << "MethodDatasetsPluginScan::readScan1dTrees() : fraction of unphysical toys: " << h_background->GetEntries() / (double)nentries * 100. << "%." << endl;
+    cout << "MethodDatasetsPluginScan::readScan1dTrees() : fraction of unphysical (negative test stat) toys: " << h_background->GetEntries() / (double)nentries * 100. << "%." << endl;
+    cout << "MethodDatasetsPluginScan::readScan1dTrees() : fraction of unphysical (negative test stat) bkg toys: " << (bkg_pvals->GetEntries() / (double)h_all_bkg->GetBinContent(2)) * 100. << "%." << endl;
     if ( nwrongrun > 0 ) {
         cout << "\nMethodDatasetsPluginScan::readScan1dTrees() : WARNING : Read toys that differ in global chi2min (wrong run) : "
              << (double)nwrongrun / (double)(nentries - nfailed) * 100. << "%.\n" << endl;

--- a/core/src/MethodDatasetsPluginScan.cpp
+++ b/core/src/MethodDatasetsPluginScan.cpp
@@ -493,7 +493,7 @@ void MethodDatasetsPluginScan::readScan1dTrees(int runMin, int runMax, TString f
         // criteria for GammaCombo
         bool convergedFits      = (t.statusFree == 0. && t.statusScan == 0.) && (t.covQualFree == 3 && t.covQualScan == 3);
         bool tooHighLikelihood  = !( abs(t.chi2minToy) < 1e27 && abs(t.chi2minGlobalToy) < 1e27);
-        // bool BadBkgFit          = (!(t.statusFreeBkg == 0 && t.statusBkgBkg == 0) && (t.covQualFreeBkg == 3 && t.covQualBkgBkg == 3))||(std::isnan(t.chi2minBkgBkgToy - t.chi2minGlobalBkgToy)||(t.chi2minBkgBkgToy - t.chi2minGlobalBkgToy<-1.e-6)||(t.statusBkgBkg!=0)||(t.statusFreeBkg!=0));
+        // bool BadBkgFit          = (!(t.statusFreeBkg == 0 && t.statusBkgBkg == 0) && (t.covQualFreeBkg == 3 && t.covQualBkgBkg == 3))||(std::isnan(t.chi2minBkgBkgToy - t.chi2minGlobalBkgToy)||(t.chi2minBkgBkgToy - t.chi2minGlobalBkgToy<0)||(t.statusBkgBkg!=0)||(t.statusFreeBkg!=0));
         bool BadBkgFit          = (!(t.statusFreeBkg == 0 && t.statusScanBkg == 0) && (t.covQualFreeBkg == 3 && t.covQualScanBkg == 3))||(std::isnan(t.chi2minBkgToy - t.chi2minGlobalBkgToy)||(abs(t.chi2minBkgToy) > 1e27 || abs(t.chi2minGlobalBkgToy) > 1e27));
         // bool BadBkgFit          = false;
 
@@ -604,17 +604,17 @@ void MethodDatasetsPluginScan::readScan1dTrees(int runMin, int runMax, TString f
         }
 
         // chi2minToy is the best of the toy at scanpoint, chi2minGlobalToy is the best global fit of the toy
-        if(valid && sb_teststat_toy>-1.e-6){
-            if(sb_teststat_toy<0&&sb_teststat_toy>-1.e-6) sb_teststat_toy = 0.0;
+        if(valid && sb_teststat_toy>=0){
+            // if(sb_teststat_toy<0&&sb_teststat_toy>=0) sb_teststat_toy = 0.0;
             sampledSchi2Values[hBin].push_back(sb_teststat_toy);
         }
 
 
         // chi2minBkgBkgToy is the best fit of the bkg pdf of bkg-only toy, chi2minGlobalBkgToy is the best global fit of the bkg-only toy
         // chi2minBkgToy is the best fit at scanpoint of bkg-only toy
-        if(b_teststat_toy<0&&b_teststat_toy>-1.e-6) b_teststat_toy=0.0;
+        // if(b_teststat_toy<0&&b_teststat_toy>0) b_teststat_toy=0.0;
 
-        if( !BadBkgFit && b_teststat_toy>-1.e-6){
+        if( !BadBkgFit && b_teststat_toy>=0){
             if(hBin==2){
                 // std::cout << bkgTestStatVal << std::endl;
                 bkg_pvals->Fill(TMath::Prob(b_teststat_toy,1));
@@ -623,7 +623,7 @@ void MethodDatasetsPluginScan::readScan1dTrees(int runMin, int runMax, TString f
             sampledBValues[hBin].push_back( b_teststat_toy );
             sampledSBValues[hBin].push_back( b_teststat_toy );
         }
-        else if (!BadBkgFit && b_teststat_toy<-1.e-6){
+        else if (!BadBkgFit && b_teststat_toy<0){
             h_negtest_bkg->Fill(t.scanpoint);
         }
 

--- a/core/src/MethodPluginScan.cpp
+++ b/core/src/MethodPluginScan.cpp
@@ -932,7 +932,7 @@ TH1F* MethodPluginScan::analyseToys(ToyTree* t, int id)
         // Check if toys are in physical region.
         // Don't enforce t.chi2min-t.chi2minGlobal>0, else it can be hard because due
         // to little fluctuaions the best fit point can be missing from the plugin plot...
-        bool inPhysicalRegion = t->chi2minToy - t->chi2minGlobalToy>0; //&& t.chi2min-t.chi2minGlobal>0
+        bool inPhysicalRegion = t->chi2minToy - t->chi2minGlobalToy>=0; //&& t.chi2min-t.chi2minGlobal>0
         int iBinBestFit = hCL->GetMaximumBin();
         float bestfitpoint = hCL->GetBinCenter(iBinBestFit);
         if(getSolution()){
@@ -992,7 +992,7 @@ TH1F* MethodPluginScan::analyseToys(ToyTree* t, int id)
             sampledSchi2Values[hBin].push_back(sb_teststat_toy);
         }
 
-        if(b_teststat_toy<0&&b_teststat_toy>-1.e-4) b_teststat_toy=0.0;
+        // if(b_teststat_toy<0&&b_teststat_toy>-1.e-4) b_teststat_toy=0.0;
 
         if( inPhysicalRegion ){
             // bkgTestStatVal = t->scanbestBkgfitBkg <= 0. ? bkgTestStatVal : 0.;  // if muhat < mu then q_mu = 0

--- a/core/src/MethodPluginScan.cpp
+++ b/core/src/MethodPluginScan.cpp
@@ -1021,7 +1021,7 @@ TH1F* MethodPluginScan::analyseToys(ToyTree* t, int id)
     if ( arg->debug ) cout << "MethodPluginScan::analyseToys() : ";
     cout << "fraction of failed toys: " << (double)nfailed/(double)nentries*100. << "%." << endl;
     if ( arg->debug ) cout << "MethodPluginScan::analyseToys() : ";
-    cout << "fraction of background toys: " << h_background->GetEntries()/(double)nentries*100. << "%." << endl;
+    cout << "fraction of negative test stat toys: " << h_background->GetEntries()/(double)nentries*100. << "%." << endl;
     if ( id==-1 && nwrongrun>0 ){
         cout << "\nMethodPluginScan::analyseToys() : WARNING : Read toys that differ in global chi2min (wrong run) : "
             << (double)nwrongrun/(double)(nentries-nfailed)*100. << "%.\n" << endl;

--- a/core/src/OneMinusClPlot.cpp
+++ b/core/src/OneMinusClPlot.cpp
@@ -438,18 +438,20 @@ void OneMinusClPlot::scan1dCLsPlot(MethodAbsScan *s, bool smooth, bool obsError)
     double *yvalsRawExpErr1Up = gErr1UpRaw->GetY();
     double *yvalsRawExpErr2Up = gErr2UpRaw->GetY();
 
-    for (int i=0; i<gExp->GetN(); i++){
-    	// std::cout << xvalsRaw[i] << "\t" <<xvals[i] << std::endl;
-    	// if(yvalsRawExp[i]>0.99){
-    	// 	gExp->SetPoint(i,xvals[i], 1.0);
-    	// }
-    	if(yvalsRawExpErr1Up[i]>0.99){
-    		gErr1Up->SetPoint(i,xvals[i], 1.0);
-    	}
-    	if(yvalsRawExpErr2Up[i]>0.99){
-    		gErr2Up->SetPoint(i,xvals[i], 1.0);
-    	}
-    }
+    if(arg->teststatistic == 1){
+	    for (int i=0; i<gExp->GetN(); i++){
+	    	// std::cout << xvalsRaw[i] << "\t" <<xvals[i] << std::endl;
+	    	// if(yvalsRawExp[i]>0.99){
+	    	// 	gExp->SetPoint(i,xvals[i], 1.0);
+	    	// }
+	    	if(yvalsRawExpErr1Up[i]>0.99){
+	    		gErr1Up->SetPoint(i,xvals[i], 1.0);
+	    	}
+	    	if(yvalsRawExpErr2Up[i]>0.99){
+	    		gErr2Up->SetPoint(i,xvals[i], 1.0);
+	    	}
+	    }
+	}
 
     // fix point 0 to CLs=1 for all expected curves
 

--- a/tutorial/main/tutorial_dataset.cpp
+++ b/tutorial/main/tutorial_dataset.cpp
@@ -68,7 +68,8 @@ int main(int argc, char* argv[])
   PDF_Datasets* pdf = new PDF_Datasets(workspace);
   // PDF_Datasets* pdf = new PDF_DatasetTutorial(workspace); // put your inherited fitter if you want to
   pdf->initData("data"); // this is the name of the dataset in the workspace
-  pdf->initBkgPDF("extended_bkg_model"); // this the name of the background pdf in the workspace (without the constraints)
+  pdf->initBkgPDF("extended_bkg_model"); // optional: this the name of the background pdf in the workspace (without the constraints)
+  // it might be feasible to comment the above line. Then the tool will assume the BkgPDF to be the PDF with scanVar=0 (most often true)
   pdf->initPDF("mass_model"); // this the name of the pdf in the workspace (without the constraints)
   pdf->initObservables("datasetObservables"); // non-global observables whose measurements are stored in the dataset (for example the mass).
   pdf->initGlobalObservables("global_observables_set"); // global observables


### PR DESCRIPTION
bkg-only test statistic distributions were allowed to be stronly negative, as spotted in #213. Now those are excluded as in the s+b case. But we should have a control plot flagging this issue if many negative test statistic values pop up.