### PR TITLE
A few additions for new compilers

### DIFF
--- a/core/include/PDF_Abs.h
+++ b/core/include/PDF_Abs.h
@@ -13,6 +13,7 @@
 #include <stdlib.h>
 #include <vector>
 
+#include "RooFormulaVar.h"
 #include "RooGlobalFunc.h"
 #include "RooWorkspace.h"
 #include "RooDataSet.h"

--- a/core/include/Utils.h
+++ b/core/include/Utils.h
@@ -9,6 +9,7 @@
 #define Utils_h
 
 #include "TMath.h"
+#include "TObjString.h"
 #include "TString.h"
 #include "TH2F.h"
 #include "TStyle.h"
@@ -19,6 +20,7 @@
 #include "TPaveText.h"
 #include "rdtsc.h"
 #include "TMatrixDSym.h"
+#include "RooFormulaVar.h"
 #include "RooRealVar.h"
 #include "RooFitResult.h"
 #include "RooSlimFitResult.h"
@@ -87,8 +89,8 @@ namespace Utils
 	RooFitResult*   fitToMinForce(RooWorkspace *w, TString name, TString forceVariables="");
 	RooFitResult*   fitToMinImprove(RooWorkspace *w, TString name);
 	double          getChi2(RooAbsPdf *pdf);
-	TH1F*           histHardCopy(const TH1F* h, bool copyContent=true, bool uniqueName=true);
-	TH2F*           histHardCopy(const TH2F* h, bool copyContent=true, bool uniqueName=true);
+	TH1F*           histHardCopy(const TH1F* h, bool copyContent=true, bool uniqueName=true, TString specName="");
+	TH2F*           histHardCopy(const TH2F* h, bool copyContent=true, bool uniqueName=true, TString specName="");
 
 	TTree*  convertRooDatasetToTTree(RooDataSet *d);
   TGraph* convertTH1ToTGraph(TH1* h, bool withErrors=false);
@@ -121,6 +123,8 @@ namespace Utils
 	void buildCorMatrix(TMatrixDSym &cor);
 	TMatrixDSym* buildCovMatrix(TMatrixDSym &cor, float *err);
 	TMatrixDSym* buildCovMatrix(TMatrixDSym &cor, vector<double> &err);
+
+  RooFormulaVar* makeTheoryVar(TString name, TString title, TString formula, RooArgList* pars);
 
 	void savePlot(TCanvas *c1, TString name);
 	bool FileExists( TString strFilename );

--- a/core/src/Combiner.cpp
+++ b/core/src/Combiner.cpp
@@ -357,13 +357,53 @@ void Combiner::print()
 {
 	if ( pdfs.size()==0 ) return;
 	cout << "\nCombiner Configuration: " << title << endl;
-	cout <<   "=======================\n" << endl;
+	cout <<   "=======================" << endl;
 	// consice summary
 	for (int i=0; i<pdfs.size(); i++ ){
 		TString name = pdfs[i]->getName();
 		name.ReplaceAll(pdfs[i]->getUniqueID(),"");
 		printf("%2i. [measurement %3i] %-65s\n", i+1, pdfs[i]->getGcId(), (pdfs[i]->getTitle()).Data());
 	}
+	if ( arg->verbose ) {
+    cout <<   "=======================" << endl;
+    // print observables of the combination
+    vector<string>& olist = getObservableNames();
+    TString obslist = "";
+    obslist += Form("%4d input observables: (",int(olist.size()));
+    int indent_length = obslist.Length();
+    int cur_length = obslist.Length();
+    for (int o=0; o<olist.size()-1; o++) {
+      obslist += " "+olist[o]+",";
+      cur_length += olist[o].length()+2;
+      if ( cur_length > 100 ) {
+        cur_length = indent_length;
+        obslist += "\n";
+        for (int i=0; i<indent_length; i++) obslist += " ";
+      }
+    }
+    obslist += " "+olist[olist.size()-1] + " )";
+    cout << obslist << endl;
+
+    // print free parameters of the combination
+    vector<string>& plist = getParameterNames();
+    TString parlist = "";
+    parlist += Form("%4d free parameters:   (",int(plist.size()));
+    indent_length = parlist.Length();
+    cur_length = parlist.Length();
+    for (int p=0; p<plist.size()-1; p++) {
+      parlist += " "+plist[p]+",";
+      cur_length += plist[p].length()+2;
+      if ( cur_length > 100 ) {
+        cur_length = indent_length;
+        parlist += "\n";
+        for (int i=0; i<indent_length; i++) parlist += " ";
+      }
+    }
+    parlist += " "+plist[plist.size()-1] + " )";
+    cout << parlist << endl;
+  }
+	cout <<   "=======================" << endl;
+
 	// verbose printout
 	if ( arg->verbose ){
 		cout << "\nDetailed Configuration:" << endl;

--- a/core/src/GammaComboEngine.cpp
+++ b/core/src/GammaComboEngine.cpp
@@ -1121,13 +1121,13 @@ void GammaComboEngine::scanStrategy2d(MethodProbScan *scanner, ParameterCache *p
 		for ( int i=0; i<s1->getSolutions().size(); i++ ) solutions.push_back(s1->getSolution(i));
 		for ( int i=0; i<s2->getSolutions().size(); i++ ) solutions.push_back(s2->getSolution(i));
 		// \todo remove similar solutions from list
+		delete s1;
+		delete s2;
 		for ( int j=0; j<solutions.size(); j++ ){
 			cout << "2D scan " << j+1 << " of " << solutions.size() << " ..." << endl;
 			scanner->loadParameters(solutions[j]);
 			scanner->scan2d();
 		}
-		delete s1;
-		delete s2;
 	}
 	// otherwise load each starting value found
 	else {

--- a/core/src/MethodAbsScan.cpp
+++ b/core/src/MethodAbsScan.cpp
@@ -285,7 +285,9 @@ void MethodAbsScan::initScan()
 		setLimit(w, scanVar2, "scan");
 		float min2 = par2->getMin();
 		float max2 = par2->getMax();
+    if (hCL2d) delete hCL2d;
 		hCL2d      = new TH2F("hCL2d"+getUniqueRootName(),      "hCL2d"+pdfName, nPoints2dx, min1, max1, nPoints2dy, min2, max2);
+    if (hChi2min2d) delete hChi2min2d;
 		hChi2min2d = new TH2F("hChi2min2d"+getUniqueRootName(), "hChi2min",      nPoints2dx, min1, max1, nPoints2dy, min2, max2);
 		for ( int i=1; i<=nPoints2dx; i++ )
 			for ( int j=1; j<=nPoints2dy; j++ ) hChi2min2d->SetBinContent(i,j,1e6);
@@ -609,7 +611,7 @@ bool MethodAbsScan::interpolate(TH1F* h, int i, float y, float central, bool upp
 	double sol1 = pq(p[0], p[1], p[2], y, 1);
 	// cout << upper << " ";
 	// printf("%f %f %f\n", central, sol0, sol1);
-	std::cout << central << "\t" << sol0 << "\t" <<sol1 << std::endl;
+  //std::cout << central << "\t" << sol0 << "\t" <<sol1 << std::endl;
 
 	// debug: show fitted 1-CL histogram
 	if ( arg->controlplot)

--- a/core/src/MethodDatasetsProbScan.cpp
+++ b/core/src/MethodDatasetsProbScan.cpp
@@ -84,7 +84,7 @@ void MethodDatasetsProbScan::initScan() {
     if(scanVar1==scanVar2){
         if(arg->debug) std::cout << "DEBUG: MethodDatasetsProbScan::initScan() : scanning y range" << std::endl;
         min1 = arg->scanrangeyMin;
-        max1 = arg->scanrangeyMax;        
+        max1 = arg->scanrangeyMax;
     }
 
     hCL = new TH1F("hCL" + getUniqueRootName(), "hCL" + pdf->getPdfName(), nPoints1d, min1, max1);
@@ -166,7 +166,7 @@ void MethodDatasetsProbScan::initScan() {
     chi2minGlobal = 2 * pdf->getMinNll();
     std::cout << "=============== Global minimum (2*-Log(Likelihood)) is: 2*" << globalMin->minNll() << " = " << chi2minGlobal << endl;
     // background only
-    // if ( !pdf->getBkgPdf() ) 
+    // if ( !pdf->getBkgPdf() )
       bkgOnlyFitResult = pdf->fitBkg(pdf->getData(), arg->var[0]); // fit on data w/ bkg only hypoth
       assert(bkgOnlyFitResult);
       bkgOnlyFitResult->SetName("bkgOnlyFitResult");
@@ -464,7 +464,7 @@ int MethodDatasetsProbScan::scan1d(bool fast, bool reverse)
         // also save the chi2 of the free data fit to the tree:
         this->probScanTree->chi2minGlobal = this->getChi2minGlobal();
         probScanTree->covQualFree = globalMin->covQual();
-        probScanTree->statusFree = globalMin->status();        
+        probScanTree->statusFree = globalMin->status();
         this->probScanTree->chi2minBkg = this->getChi2minBkg();
         if(bkgOnlyFitResult){
             probScanTree->statusFreeBkg = bkgOnlyFitResult->status();
@@ -614,13 +614,13 @@ int MethodDatasetsProbScan::scan2d()
     cDbg->SetMargin(0.1,0.15,0.1,0.1);
     float hChi2min2dMin = hChi2min2d->GetMinimum();
     bool firstScanDone = hChi2min2dMin<1e5;
-    TH2F *hDbgChi2min2d = histHardCopy(hChi2min2d, firstScanDone);
+    TH2F *hDbgChi2min2d = histHardCopy(hChi2min2d, firstScanDone, true);
     hDbgChi2min2d->SetTitle(Form("#Delta#chi^{2} for scan %i, %s",nScansDone,title.Data()));
     if ( firstScanDone ) hDbgChi2min2d->GetZaxis()->SetRangeUser(hChi2min2dMin,hChi2min2dMin+25);
     hDbgChi2min2d->GetXaxis()->SetTitle(par1->GetTitle());
     hDbgChi2min2d->GetYaxis()->SetTitle(par2->GetTitle());
     hDbgChi2min2d->GetZaxis()->SetTitle("#Delta#chi^{2}");
-    TH2F *hDbgStart = histHardCopy(hChi2min2d, false);
+    TH2F *hDbgStart = histHardCopy(hChi2min2d, false, true);
 
 
     // start coordinates //Titus: start at the global minimum
@@ -800,6 +800,11 @@ int MethodDatasetsProbScan::scan2d()
         cout << "MethodDatasetsProbScan::scan2d() :          min chi2 found in scan: " << bestMinFoundInScan << ", old min chi2: " << bestMinOld << endl;
         return 1;
     }
+
+  // cleanup
+  if (hDbgChi2min2d) delete hDbgChi2min2d;
+  if (hDbgStart) delete hDbgStart;
+
     return 0;
 }
 

--- a/core/src/MethodProbScan.cpp
+++ b/core/src/MethodProbScan.cpp
@@ -466,13 +466,13 @@ int MethodProbScan::scan2d()
 	cDbg->SetMargin(0.1,0.15,0.1,0.1);
 	float hChi2min2dMin = hChi2min2d->GetMinimum();
 	bool firstScanDone = hChi2min2dMin<1e5;
-	TH2F *hDbgChi2min2d = histHardCopy(hChi2min2d, firstScanDone);
+	TH2F *hDbgChi2min2d = histHardCopy(hChi2min2d, firstScanDone, true, TString(hChi2min2d->GetName())+TString("_Dbg"));
 	hDbgChi2min2d->SetTitle(Form("#Delta#chi^{2} for scan %i, %s",nScansDone,title.Data()));
 	if ( firstScanDone ) hDbgChi2min2d->GetZaxis()->SetRangeUser(hChi2min2dMin,hChi2min2dMin+81);
 	hDbgChi2min2d->GetXaxis()->SetTitle(par1->GetTitle());
 	hDbgChi2min2d->GetYaxis()->SetTitle(par2->GetTitle());
 	hDbgChi2min2d->GetZaxis()->SetTitle("#Delta#chi^{2}");
-	TH2F *hDbgStart = histHardCopy(hChi2min2d, false);
+	TH2F *hDbgStart = histHardCopy(hChi2min2d, false, true, TString(hChi2min2d->GetName())+TString("_DbgSt"));
 
 	// start coordinates
 	// don't allow the under/overflow bins
@@ -635,6 +635,11 @@ int MethodProbScan::scan2d()
 		cout << "MethodProbScan::scan2d() :          min chi2 found in scan: " << bestMinFoundInScan << ", old min chi2: " << bestMinOld << endl;
 		return 1;
 	}
+
+  // cleanup
+  if (hDbgChi2min2d) delete hDbgChi2min2d;
+  if (hDbgStart) delete hDbgStart;
+
 	return 0;
 }
 

--- a/core/src/PDF_Abs.cpp
+++ b/core/src/PDF_Abs.cpp
@@ -388,6 +388,14 @@ void PDF_Abs::print() const
 			ostringstream stream;
 			v->printMetaArgs(stream);
 			TString formula = stream.str();
+      if ( formula.Contains("formula=") ) { // this is a RooFormulaVar
+        RooFormulaVar *form = dynamic_cast<RooFormulaVar*>(v);
+        int nFormPars = form->getVariables()->getSize();
+        for (int i=0; i<nFormPars; i++) {
+          if ( ! form->getParameter(i) ) continue;
+          formula.ReplaceAll( Form("x[%d]",i), form->getParameter(i)->GetName() );
+        }
+      }
 			formula.ReplaceAll("formula=", "");
 			formula.ReplaceAll("\"", "");
 			if ( formula=="" ) formula = v->ClassName(); // compiled custom Roo*Var classes don't have a formula

--- a/core/src/Utils.cpp
+++ b/core/src/Utils.cpp
@@ -494,6 +494,7 @@ void Utils::setParameters(RooWorkspace* w, RooFitResult* values){
 			var->setVal(p->getVal());
 		}
 	}
+  delete it;
 	return;
 };
 
@@ -582,13 +583,12 @@ void Utils::setParameters(RooWorkspace* w, TString parname, RooFitResult* r, boo
 
 void Utils::setParameters(RooWorkspace* w, TString parname, RooSlimFitResult* r, bool constAndFloat)
 {
-	if ( constAndFloat ){
-		RooArgList list = r->floatParsFinal();
-		list.add(r->constPars());
-		setParameters(w, parname, &list);
-		return;
-	}
-	setParameters(w, parname, &(r->floatParsFinal()));
+  // avoid calls to floatParsFinal on a RooSlimFitResult - errgh!
+	vector<string> &names = r->_parsNames;
+  for ( int i=0; i<names.size(); i++ ) {
+    RooRealVar *var = (RooRealVar*)w->var(names[i].c_str());
+    if (var) var->setVal( r->_parsVal[i] );
+  }
 }
 
 ///

--- a/core/src/Utils.cpp
+++ b/core/src/Utils.cpp
@@ -752,6 +752,22 @@ TMatrixDSym* Utils::buildCovMatrix(TMatrixDSym &cor, vector<double> &err)
 }
 
 ///
+/// Make a theory var in which the parmaeter list gets slimmed down to only
+/// contain the relevant dependents.
+/// This is a workaround for changes in RooFormulaVar that break things when
+/// making subset pdfs
+RooFormulaVar* Utils::makeTheoryVar(TString name, TString title, TString formula, RooArgList* pars)
+{
+  RooArgList *explicitDependents = new RooArgList();
+  for ( int i=0; i<pars->getSize(); i++ ) {
+    if ( formula.Contains( TString( pars->at(i)->GetName() ) ) ) {
+      explicitDependents->add( *(pars->at(i)) );
+    }
+  }
+  return new RooFormulaVar( name, title, formula, *explicitDependents );
+}
+
+///
 /// Merge two named sets of variables inside a RooWorkspace.
 /// Duplicate variables will only be contained once.
 ///
@@ -947,9 +963,10 @@ TGraph* Utils::smoothHist(TH1* h, int option)
 /// \param uniqueName - true: append a unique string to the histogram name
 /// \return a new histogram. Caller assumes ownership.
 ///
-TH1F* Utils::histHardCopy(const TH1F* h, bool copyContent, bool uniqueName)
+TH1F* Utils::histHardCopy(const TH1F* h, bool copyContent, bool uniqueName, TString specName)
 {
 	TString name = h->GetTitle();
+  if ( specName != "" ) name = specName;
 	if ( uniqueName ) name += getUniqueRootName();
 	TH1F* hNew = new TH1F(name, h->GetTitle(),
 			h->GetNbinsX(),
@@ -966,9 +983,10 @@ TH1F* Utils::histHardCopy(const TH1F* h, bool copyContent, bool uniqueName)
 /// Creates a fresh, independent copy of the input histogram.
 /// 2d version of TH1F* Utils::histHardCopy().
 ///
-TH2F* Utils::histHardCopy(const TH2F* h, bool copyContent, bool uniqueName)
+TH2F* Utils::histHardCopy(const TH2F* h, bool copyContent, bool uniqueName, TString specName)
 {
 	TString name = h->GetTitle();
+  if ( specName != "" ) name = specName;
 	if ( uniqueName ) name += getUniqueRootName();
 	TH2F* hNew = new TH2F(name, h->GetTitle(),
 			h->GetNbinsX(),


### PR DESCRIPTION
- A few headers folders needed some extra includes for some compilers
(dicsovered on recent version of MacOS - i.e Clang16)
- Then added some more useful output when printing combination
configurations
- Added some fixes when taking subsets of pdfs (very useful when only
considering certain observables). Recent changes in ROOT to
RooFormulaVar means this no longer worked in Root >6.08 (the solution
here is back compatible)
- Also added some safety when copying histograms to avoid memory leaks