### PR TITLE
Generalise data format for the datasets procedures

### DIFF
--- a/core/include/PDF_Abs.h
+++ b/core/include/PDF_Abs.h
@@ -142,8 +142,8 @@ class PDF_Abs
 		// The following three members are to gain performance during
 		// toy generation - generating 1000 toys is much faster than 1000 times one toy.
 		int                     nToyObs;        // Number of toy observables to be pregenerated.
-		RooDataSet*             toyObservables; // A dataset holding nToyObs pregenerated bkg only toy observables.
-		RooDataSet*             toyBkgObservables; // A dataset holding nToyObs pregenerated toy observables.
+		RooAbsData*             toyObservables; // A dataset holding nToyObs pregenerated bkg only toy observables.
+		RooAbsData*             toyBkgObservables; // A dataset holding nToyObs pregenerated toy observables.
 		int                     iToyObs;        // Index of next unused set of toy observables.
 		int						gcId;			// ID of this PDF inside a GammaCombo object. Used to refer to this PDF.
 

--- a/core/include/PDF_Datasets.h
+++ b/core/include/PDF_Datasets.h
@@ -27,8 +27,8 @@ public:
     ~PDF_Datasets();
     void                  deleteNLL() {if (_NLL) {delete _NLL; _NLL = NULL;}};
 
-    virtual RooFitResult* fit(RooDataSet* dataToFit);
-    virtual RooFitResult* fitBkg(RooDataSet* dataToFit, TString signalvar);
+    virtual RooFitResult* fit(RooAbsData* dataToFit);
+    virtual RooFitResult* fitBkg(RooAbsData* dataToFit, TString signalvar);
     virtual void          generateToys(int SeedShift = 0);
     virtual void          generateToysGlobalObservables(int SeedShift = 0);
     virtual void          generateBkgToys(int SeedShift = 0, TString signalvar="");
@@ -49,7 +49,7 @@ public:
     OptParser*            getArg();
     TString               getConstraintName() {return constraintName;};
     TString               getDataName() {return dataName;};
-    RooDataSet*           getData() {return this->data;};
+    RooAbsData*           getData() {return this->data;};
     inline int            getFitStatus() {return fitStatus;};
     inline int            getFitStrategy() {return fitStrategy;};
     inline std::vector<TString>  getFitObs() {return fitObs;};
@@ -63,8 +63,8 @@ public:
     TString               getParName() {return parName;};
     TString               getPdfName() {return pdfName;};
     TString               getBkgPdfName() {return pdfBkgName;};
-    RooDataSet*           getToyObservables() {return this->toyObservables;};
-    RooDataSet*           getBkgToyObservables() {return toyBkgObservables;};
+    RooAbsData*           getToyObservables() {return this->toyObservables;};
+    RooAbsData*           getBkgToyObservables() {return toyBkgObservables;};
     RooWorkspace*         getWorkspace() {return wspc;};
     // setters
     inline void           setFitStatus(int stat = 0) {fitStatus = stat;};
@@ -75,8 +75,8 @@ public:
     void                  setNCPU(int n) {NCPU = n;};
     void                  setVarRange(const TString &varName, const TString &rangeName,
                                       const double &rangeMin, const double &rangeMax);
-    void                  setToyData(RooDataSet* ds);
-    void                  setBkgToyData(RooDataSet* ds);
+    void                  setToyData(RooAbsData* ds);
+    void                  setBkgToyData(RooAbsData* ds);
     
     void                  setGlobalObsSnapshotBkgToy(TString snapshotname) {globalObsBkgToySnapshotName = snapshotname;};
 
@@ -103,7 +103,7 @@ public:
 protected:
     void initializeRandomGenerator(int seedShift);
     RooWorkspace*   wspc;
-    RooDataSet*     data;
+    RooAbsData*     data;
     RooAbsReal*     _NLL; // possible pointer to minimization function
     RooAbsPdf*      _constraintPdf;
     TString         pdfName; //> name of the pdf in the workspace

--- a/core/src/MethodDatasetsPluginScan.cpp
+++ b/core/src/MethodDatasetsPluginScan.cpp
@@ -1153,7 +1153,7 @@ int MethodDatasetsPluginScan::scan1d(int nRun)
 		// if CLs toys we need to keep hold of what's going on in the bkg only case
     // there is a small overhead here but it's necessary because the bkg only hypothesis
     // might not necessarily be in the scan range (although often it will be the first point)
-	vector<RooDataSet*> cls_bkgOnlyToys;
+	vector<RooAbsData*> cls_bkgOnlyToys;
 	vector<TString> bkgOnlyGlobObsSnaphots;
     vector<float> chi2minGlobalBkgToysStore;    // Global fit to bkg-only toys
     vector<float> chi2minBkgBkgToysStore;       // Bkg fit to bkg-only toys
@@ -1177,8 +1177,8 @@ int MethodDatasetsPluginScan::scan1d(int nRun)
         // pdf->printParameters();
         pdf->generateBkgToys(0,arg->var[0]);
         pdf->generateBkgToysGlobalObservables(0,j);
-        RooDataSet* bkgOnlyToy = pdf->getBkgToyObservables();
-        cls_bkgOnlyToys.push_back( (RooDataSet*)bkgOnlyToy->Clone() ); // clone required because of deleteToys() call at end of loop
+        RooAbsData* bkgOnlyToy = pdf->getBkgToyObservables();
+        cls_bkgOnlyToys.push_back( (RooAbsData*)bkgOnlyToy->Clone() ); // clone required because of deleteToys() call at end of loop
         bkgOnlyGlobObsSnaphots.push_back(pdf->globalObsBkgToySnapshotName);
         pdf->setToyData( bkgOnlyToy );
         parameterToScan->setConstant(false);
@@ -1456,9 +1456,9 @@ int MethodDatasetsPluginScan::scan1d(int nRun)
             parameterToScan->setConstant(true);
             this->pdf->setFitStrategy(0);
             // temporarily store our current toy here so we can put it back in a minute
-            RooDataSet *tempData = (RooDataSet*)this->pdf->getToyObservables();
+            RooAbsData *tempData = (RooAbsData*)this->pdf->getToyObservables();
             // now get our background only toy (to fit under this hypothesis)
-            RooDataSet *bkgToy = (RooDataSet*)cls_bkgOnlyToys[j];
+            RooAbsData *bkgToy = (RooAbsData*)cls_bkgOnlyToys[j];
             if (arg->debug) cout << "Setting background toy as data " << bkgToy << endl;
             this->pdf->setBkgToyData( bkgToy );
             this->pdf->setGlobalObsSnapshotBkgToy( bkgOnlyGlobObsSnaphots[j] );

--- a/core/src/PDF_Datasets.cpp
+++ b/core/src/PDF_Datasets.cpp
@@ -62,7 +62,7 @@ void PDF_Datasets::initData(const TString& name) {
         exit(EXIT_FAILURE);
     }
     dataName    = name;
-    data        = (RooDataSet*) wspc->data(dataName);
+    data        = (RooAbsData*) wspc->data(dataName);
     if (data) isDataSet   = true;
     else {
         std::cout << "FATAL in PDF_Datasets::initData -- Data: " << dataName << " not found in workspace" << std::endl;
@@ -198,13 +198,13 @@ void PDF_Datasets::setVarRange(const TString &varName, const TString &rangeName,
 };
 
 
-void PDF_Datasets::setToyData(RooDataSet* ds) {
+void PDF_Datasets::setToyData(RooAbsData* ds) {
     toyObservables  = ds;
     isToyDataSet    = kTRUE;
     return;
 };
 
-void PDF_Datasets::setBkgToyData(RooDataSet* ds) {
+void PDF_Datasets::setBkgToyData(RooAbsData* ds) {
     toyBkgObservables  = ds;
     return;
 };
@@ -280,7 +280,7 @@ void  PDF_Datasets::generateToysGlobalObservables(int SeedShift) {
 };
 
 
-RooFitResult* PDF_Datasets::fit(RooDataSet* dataToFit) {
+RooFitResult* PDF_Datasets::fit(RooAbsData* dataToFit) {
 
     if (this->getWorkspace()->set(constraintName) == NULL) {
         std::cout << std::endl;
@@ -314,7 +314,7 @@ RooFitResult* PDF_Datasets::fit(RooDataSet* dataToFit) {
     return result;
 };
 
-RooFitResult* PDF_Datasets::fitBkg(RooDataSet* dataToFit, TString signalvar) {
+RooFitResult* PDF_Datasets::fitBkg(RooAbsData* dataToFit, TString signalvar) {
 
     if (this->getWorkspace()->set(constraintName) == NULL) {
         std::cout << std::endl;

--- a/core/src/PDF_Datasets.cpp
+++ b/core/src/PDF_Datasets.cpp
@@ -532,7 +532,7 @@ void   PDF_Datasets::generateToys(int SeedShift) {
     initializeRandomGenerator(SeedShift);
     // RooDataSet* toys = this->pdf->generate(*observables, RooFit::NumEvents(wspc->data(dataName)->numEntries()), RooFit::Extended(kTRUE));
     //
-    RooDataSet* toys;
+    RooAbsData* toys;
     if (isMultipdfSet) {
         toys = multipdf->getPdf(bestIndexScan)->generate(*observables, wspc->data(dataName)->numEntries(),false,true,"",false,true);
     }
@@ -556,7 +556,7 @@ void   PDF_Datasets::generateBkgToys(int SeedShift, TString signalvar) {
     //     // exit(EXIT_FAILURE);
     // }
     // std::cout << "WARNING in PDF_Datasets::generateBkgToys -- Fitting bkg model as sig+bkg model with " << signalvar << " to zero!" << std::endl;
-    RooDataSet* toys;
+    RooAbsData* toys;
     if (isBkgMultipdfSet) {
         toys = multipdfBkg->getPdf(bestIndexBkg)->generate(*observables, wspc->data(dataName)->numEntries(),false,true,"",false,true);
     }

--- a/tutorial/main/tutorial_dataset_multipdf.cpp
+++ b/tutorial/main/tutorial_dataset_multipdf.cpp
@@ -37,7 +37,7 @@ int main(int argc, char* argv[])
 
   PDF_Datasets* pdf = new PDF_Datasets(workspace);
   pdf->initData("data"); // this is the name of the dataset in the workspace
-  pdf->initPDF("SBmodel_polynomial"); // this the name of the pdf in the workspace (without the constraints)
+  pdf->initPDF("roomultipdf"); // this the name of the pdf in the workspace (without the constraints)
   // To compare to the behaviour with a single pdf, you can instead use pdf->initPDF("SBmodel_polynomial") (polynomial is selected for comparison because this is the pdf which achieves the global minimum in this case)
   pdf->initMultipdfCat("pdf_index"); // this is the only extra thing that needs initialising for a multipdf
   pdf->initObservables("datasetObservables"); // non-global observables whose measurements are stored in the dataset (for example the mass).


### PR DESCRIPTION
This MR aims to fix #221. In a few places the RooDataSet is replaced by RooAbsData so that
1. the normal behaviour with the use of RooDataSets should be completely unaffected
2. it should be able to move to do binned fits with RooDataHist by simply making a custom `PDF_X` class that inherits everything from the `PDF_Datasets` class apart from the toy generation.

An example for such a derived class is given in https://github.com/gammacombo/gammacombo/blob/master/tutorial/src/PDF_DatasetTutorial.cpp, where the fitting and toy generation methods are overwritten.

At the same time I added a few catches for empty RooArgSets and MultiPdf consistency.