### PR TITLE
tutorial improvements and snakefile for limit setting, fix unblind error handling

### DIFF
--- a/core/src/PDF_Datasets.cpp
+++ b/core/src/PDF_Datasets.cpp
@@ -611,6 +611,18 @@ void PDF_Datasets::initializeRandomGenerator(int seedShift) {
 
 void PDF_Datasets::unblind(TString var, TString unblindRegs) {
 
+  if(!wspc->var(var)){
+    std::cerr << "ERROR::PDF_Datasets::unblind(): the variable " << var << " is not present in the workspace."<< std::endl;
+    if(observables){
+        std::cerr << "Candidates are:";
+        TIterator* it =  observables->createIterator();
+        while (RooRealVar* obs = dynamic_cast<RooRealVar*>(it->Next())) {
+            std::cerr <<" "<<obs->GetName();
+        }
+        std::cerr<<"."<<std::endl;
+    }
+    exit(EXIT_FAILURE);
+  }
   TString unblindString = "";
   TObjArray *regs = unblindRegs.Tokenize(","); // split string at ","
   for (int i=0; i<regs->GetEntries(); i++){

--- a/tutorial/Snakefile
+++ b/tutorial/Snakefile
@@ -1,0 +1,153 @@
+# This file includes the following commands into a snakemake workflow. Any of the commands can be executed outside snakemake independently as well!
+  
+  # 0.) Create a RooWorkspace
+  #        bin/tutorial_dataset_build_workspace
+  # 1.) Running a Profile Likelihood Scan with the cls option --cls 1
+  #        bin/tutorial_dataset --var branchingRatio --npoints 50 --scanrange 0.:1.e-6 --cls 1
+  # 2.) To do a Feldman Cousins plugin scan (run a bunch in parallel and give them different names with --nrun %d
+  #        bin/tutorial_dataset -a pluginbatch --var branchingRatio --npoints 50 --scanrange 0.:1.e-6 --ntoys 100 --nrun 0
+  #        bin/tutorial_dataset -a pluginbatch --var branchingRatio --npoints 50 --scanrange 0.:1.e-6 --ntoys 100 --nrun 1
+  #        bin/tutorial_dataset -a pluginbatch --var branchingRatio --npoints 50 --scanrange 0.:1.e-6 --ntoys 100 --nrun 2
+  #        bin/tutorial_dataset -a pluginbatch --var branchingRatio --npoints 50 --scanrange 0.:1.e-6 --ntoys 100 --nrun 3
+  #        bin/tutorial_dataset -a pluginbatch --var branchingRatio --npoints 50 --scanrange 0.:1.e-6 --ntoys 100 --nrun 4
+  # 3.) Read a bunch of Feldman Cousins scans back in (use the -j option to label the different run numbers), use the --cls 2 option
+  #        bin/tutorial_dataset -a plugin --var branchingRatio --npoints 50 --scanrange 0.:1.e-6 -j 1-5 -a plot --cls 1 --cls 2
+
+# This file is just performing program executions. Make sure you have compiled the program properly before executing with snakemake!
+# If you encounter any problems contact Matthew Kenzie (matthew.kenzie@cern.ch) or Titus Mombächer (titus.mombacher@cern.ch)
+
+
+# setup the environment on lxplus, needed for every rule, since the rules can run independently
+SETUP_LXPLUS_PREFIX = ' ;'.join([
+  'export PATH=/usr/local/bin:/usr/bin',
+  'set +u',
+  'source ../scripts/setup_lxplus.sh',
+  # 'set -u',
+  ' ',
+  ])
+
+# some parameter definitions to generalise the snakefile (can be specified in a separate config if desired)
+combiner_name = "PDF_Dataset" # default name, can be defined in "tutorial_dataset.cpp"
+nscanpoints = 50
+scanvar = "branchingRatio"
+scanrange = "0:1.e-6"
+ntoys_per_run = 100
+nruns = 5
+
+
+
+rule all:
+  input:
+    'workspace.root',
+    'root/scan1dDatasetsProb_{combiner_name}_{nscanpoints}p_{scanvar}.root'.format(combiner_name=combiner_name, nscanpoints=nscanpoints, scanvar=scanvar),
+    expand('root/scan1dDatasetsPlugin_{combiner_name}_{scanvar}/scan1dDatasetsPlugin_{combiner_name}_{scanvar}_run{jobnum}.root', combiner_name=combiner_name, scanvar=scanvar, jobnum=list(range(nruns))),
+    'plots/cl/clintervals_{combiner_name}_{scanvar}_DatasetsPlugin.py'.format(combiner_name=combiner_name, scanvar=scanvar),
+    'plots/cl/clintervals_{combiner_name}_{scanvar}_DatasetsPlugin_CLs2.py'.format(combiner_name=combiner_name, scanvar=scanvar),
+    'plots/cl/clintervals_{combiner_name}_{scanvar}_DatasetsPlugin_expected_standardCLs.py'.format(combiner_name=combiner_name, scanvar=scanvar)
+
+rule build_wspc:
+  output:
+    'workspace.root'
+
+  threads: 1  # this will set request_cpus to 1, this is also used when not submitting to the cluster, always set the correct value here
+  # resources:
+  #     request_memory = 1024,  # in mb, more than enough
+  #     MaxRunHours = 1,  # defining the queue, 1 hour is more than enough
+  #     request_disk = 1024000  # in kb, more than enough
+  log:
+    'build_workspace.log'       
+  shell:
+    SETUP_LXPLUS_PREFIX+
+      ' '.join([
+          'bin/tutorial_dataset_build_workspace',
+          '> {log}'
+      ])
+
+rule run_prob:
+  input:
+    'workspace.root'
+  output:
+    'root/scan1dDatasetsProb_{name}_{points}p_{var}.root'
+
+
+  threads: 1  # this will set request_cpus to 1, this is also used when not submitting to the cluster, always set the correct value here
+  # resources:
+  #     request_memory = 1024,  # in mb, more than enough
+  #     MaxRunHours = 1,  # defining the queue, 1 hour is more than enough
+  #     request_disk = 1024000   # in kb, more than enough
+  log:
+    'tutorial_dataset_prob_{name}_{points}p_{var}.log'       
+  shell:
+    SETUP_LXPLUS_PREFIX+
+      ' '.join([
+          'bin/tutorial_dataset',
+          '--var {wildcards.var}',
+          '--npoints {wildcards.points}',
+          '--scanrange '+scanrange,
+          '--cls 2', # calculates the cls method
+          '--CL 90', # calculates the limit at 90% CL
+          '--CL 95', # calculates the limit at 95% CL
+          '> {log}'
+      ])
+
+rule run_pluginbatch:
+  input:
+    'workspace.root',
+    'root/scan1dDatasetsProb_{name}_'+str(nscanpoints)+'p_{var}.root',
+
+  output:
+    'root/scan1dDatasetsPlugin_{name}_{var}/scan1dDatasetsPlugin_{name}_{var}_run{jobnum}.root'
+
+  threads: 1  # this will set request_cpus to 1, this is also used when not submitting to the cluster, always set the correct value here
+  # resources:
+  #     request_memory = 1024, # in mb, more than enough
+  #     MaxRunHours = 1,  # defining the queue, the batch scan can be quite time consuming (very problem dependent), here 1h is enough
+  #     request_disk = 1024000  # in kb, more than enough
+  log:
+    'tutorial_dataset_pluginbatch_{name}_{var}_{jobnum}.log'       
+  shell:
+    SETUP_LXPLUS_PREFIX+
+      ' '.join([
+          'bin/tutorial_dataset',
+          '--var {wildcards.var}',
+          '--npoints '+str(nscanpoints),
+          '--scanrange '+scanrange,
+          '-a pluginbatch',
+          '--ntoys '+str(ntoys_per_run),
+          '--nrun {wildcards.jobnum}'
+          ' > {log}'
+      ])
+
+
+rule run_plugin:
+  input:
+    'workspace.root',
+    'root/scan1dDatasetsProb_{name}_'+str(nscanpoints)+'p_{var}.root',
+    expand('root/scan1dDatasetsPlugin_{name}_{var}/scan1dDatasetsPlugin_{name}_{var}_run{jobnum}.root',name=combiner_name, var=scanvar, jobnum=list(range(nruns)))
+
+  output:
+    'plots/cl/clintervals_{name}_{var}_DatasetsPlugin.py',
+    'plots/cl/clintervals_{name}_{var}_DatasetsPlugin_CLs2.py',
+    'plots/cl/clintervals_{name}_{var}_DatasetsPlugin_expected_standardCLs.py'
+
+  threads: 1  # this will set request_cpus to 1, this is also used when not submitting to the cluster, always set the correct value here
+  # resources:
+  #     request_memory = 1024,  # in mb, more than enough
+  #     MaxRunHours = 1,  # defining the queue, 1 hour is more than enough
+  #     request_disk = 1024000  # in kb, more than enough
+  log:
+    'tutorial_dataset_plugin_{name}_{var}.log'       
+  shell:
+    SETUP_LXPLUS_PREFIX+
+      ' '.join([
+          'bin/tutorial_dataset',
+          '--var {wildcards.var}',
+          '--npoints '+str(nscanpoints),
+          '--scanrange '+scanrange,
+          '-a plugin',
+          '-j 0-'+str(nruns-1),
+          '--cls 2', # calculates the cls method
+          '--CL 90', # calculates the limit at 90% CL
+          '--CL 95', # calculates the limit at 95% CL
+          '> {log}'
+      ])

--- a/tutorial/Snakefile
+++ b/tutorial/Snakefile
@@ -1,4 +1,4 @@
-# This file includes the following commands into a snakemake workflow. Any of the commands can be executed outside snakemake independently as well!
+# This file includes the following commands into a snakemake workflow (optimised to work on LXPLUS). Any of the commands can be executed outside snakemake independently as well!
   
   # 0.) Create a RooWorkspace
   #        bin/tutorial_dataset_build_workspace

--- a/tutorial/main/tutorial_dataset.cpp
+++ b/tutorial/main/tutorial_dataset.cpp
@@ -41,6 +41,7 @@ int main(int argc, char* argv[])
   // 8.) There are various ways of prettyfying your plots - for CLs stuff you can try adding --qh 23 (moves the CL label) --group LHCb (adds LHCb label) --prelim (add preliminary label)
   //        bin/tutorial_dataset -a plugin --var branchingRatio --npoints 50 --scanrange 0.:1.e-6 -j 1-5 -a plot --cls 1 --cls 2 --qh 23 --group LHCb --prelim
   //
+  // See also the Snakefile in the tutorial top directory for an example workflow
   // If you have any problems contact Matthew Kenzie (matthew.kenzie@cern.ch) or Titus Mombächer (titus.mombacher@cern.ch)
 
   // Load the workspace from its file
@@ -79,7 +80,7 @@ int main(int argc, char* argv[])
   pdf->initConstraints("constraint_set"); // RooArgSet containing the "constraint" PDF's
   // the below are optional (will not affect the results but just make some plots for you)
   pdf->addFitObs("mass");                         // this is not required but will make some sanity plots
-  //pdf->unblind("mass","[4360:5260],[5460:6360]"); // have to be a bit careful about staying blind (this code isn't yet really blind friendly)
+  // pdf->unblind("mass","[4360:5260],[5460:6360]"); // have to be a bit careful about staying blind (this code isn't yet really blind friendly)
   pdf->unblind("mass", "[4360:6360]" );
 
   // pdf->printParameters();

--- a/tutorial/main/tutorial_dataset.cpp
+++ b/tutorial/main/tutorial_dataset.cpp
@@ -36,7 +36,7 @@ int main(int argc, char* argv[])
   //        bin/tutorial_dataset -a plugin --var branchingRatio --npoints 50 --scanrange 0.:1.e-6 -j 1-5
   // 6.) To just plot the Feldman Cousins stuff without having to re-scan or re-read add the -a plot option again
   //        bin/tutorial_dataset -a plugin --var branchingRatio --npoints 50 --scanrange 0.:1.e-6 -j 1-5 -a plot
-  // 7.) The F-C CLs method is a bit overkill (to do the classic CLs thing (with the FC toys) and plot the expected values as well) use the --cls 2 option (note you can pass --cls multiple times)
+  // 7.) To do the full toy-based CLs method and plot the expected values as well) use the --cls 2 option (note you can pass --cls multiple times)
   //        bin/tutorial_dataset -a plugin --var branchingRatio --npoints 50 --scanrange 0.:1.e-6 -j 1-5 -a plot --cls 1 --cls 2
   // 8.) There are various ways of prettyfying your plots - for CLs stuff you can try adding --qh 23 (moves the CL label) --group LHCb (adds LHCb label) --prelim (add preliminary label)
   //        bin/tutorial_dataset -a plugin --var branchingRatio --npoints 50 --scanrange 0.:1.e-6 -j 1-5 -a plot --cls 1 --cls 2 --qh 23 --group LHCb --prelim

--- a/tutorial/main/tutorial_dataset.cpp
+++ b/tutorial/main/tutorial_dataset.cpp
@@ -67,15 +67,17 @@ int main(int argc, char* argv[])
 
   PDF_Datasets* pdf = new PDF_Datasets(workspace);
   // PDF_Datasets* pdf = new PDF_DatasetTutorial(workspace); // put your inherited fitter if you want to
+  // pdf->setTitle("datasets_combiner"); // give a meaningful title if you want to, default is "PDF_Dataset"
+  // pdf->setName("datasets_combiner"); // give a meaningful name if you want to (will enter file names as well), default is "PDF_Dataset"
   pdf->initData("data"); // this is the name of the dataset in the workspace
-  pdf->initBkgPDF("extended_bkg_model"); // optional: this the name of the background pdf in the workspace (without the constraints)
-  // it might be feasible to comment the above line. Then the tool will assume the BkgPDF to be the PDF with scanVar=0 (most often true)
   pdf->initPDF("mass_model"); // this the name of the pdf in the workspace (without the constraints)
+  // pdf->initBkgPDF("extended_bkg_model"); // optional: this the name of the background pdf in the workspace (without the constraints)
+  // If the above line is commented, the tool will assume the BkgPDF to be the PDF with scanVar=0 (most often true)
   pdf->initObservables("datasetObservables"); // non-global observables whose measurements are stored in the dataset (for example the mass).
   pdf->initGlobalObservables("global_observables_set"); // global observables
   pdf->initParameters("parameters"); // all parameters
   pdf->initConstraints("constraint_set"); // RooArgSet containing the "constraint" PDF's
-  // the below are optional (will not effect the results but just make some plots for you)
+  // the below are optional (will not affect the results but just make some plots for you)
   pdf->addFitObs("mass");                         // this is not required but will make some sanity plots
   //pdf->unblind("mass","[4360:5260],[5460:6360]"); // have to be a bit careful about staying blind (this code isn't yet really blind friendly)
   pdf->unblind("mass", "[4360:6360]" );


### PR DESCRIPTION
I wrote a little snakefile for limit setting with the tutorial_datasets case that can run on LXPLUS.
Also I modified a little the datasets tutorial, most importantly removing the specification of the background pdf as default. One can specify the background pdf, but I have encountered relatively often that a bkg+sig pdf with sig=0 behaves a bit different than the bkg-only pdf. I didn't find the cause, but must be somewhere related to RooFit. The pdf configuration bkg+sig with sig=0 behaves more consistently with the full bkg+sig pdf.