### PR TITLE
Fixing small bug in multipdf prange implementation behaviour

### DIFF
--- a/core/src/MethodDatasetsPluginScan.cpp
+++ b/core/src/MethodDatasetsPluginScan.cpp
@@ -1197,6 +1197,7 @@ int MethodDatasetsPluginScan::scan1d(int nRun)
                 assert(rb);
             }
         }
+        Utils::setParameters(w,rb); // set parameters to fitresult of best fit before making refitting decision, necessary if using multipdf
         // implement physical range a la Feldman Cousins
         bool refit_necessary = false;
         if ( arg->physRanges.size()>0 ){
@@ -1628,6 +1629,7 @@ int MethodDatasetsPluginScan::scan1d(int nRun)
                 }
             }
 
+            Utils::setParameters(w,r1); //  set parameters to fitresult of best fit before making refitting decision, necessary if using multipdf
             // implement physical range a la Feldman Cousins
             bool refit_necessary = false;
             std::map<TString, double> boundary_vals;


### PR DESCRIPTION
This fixes a small bug in the decision to refit with prange implemented when using a multipdf. Essentially, this is made using the final fit, when it should be made using the best fit. This matters if the POI is in the prange for the best fit and not in the final fit, or vice versa. 

I think this can be fixed simply by using Utils::setParameters to set the parameters to their best (rather than final) fit values before deciding whether to fix and refit. This is the only change I have made.

This only affects the free fit to B-only and S+B toys in MethodDatasetPluginScan. The global fit at the start of this script already had the desired behaviour.

I have checked that in the two relevant places:

- If the best fit is outside the prange, the prange implementation and refit is triggered, even if the final fit is inside the prange
- If the best fit is inside the prange the prange implementation is not triggered, even if the final fit is outside the prange
- When using a normal pdf, the values of parameters in the workspace are not affected