### PR TITLE
WIP: asymptotic expected cls with asimov data sets

### DIFF
--- a/core/include/MethodAbsScan.h
+++ b/core/include/MethodAbsScan.h
@@ -44,7 +44,7 @@ class OneMinusClPlotAbs;
 class MethodAbsScan
 {
 	public:
-				MethodAbsScan();
+		MethodAbsScan();
 		MethodAbsScan(Combiner* c);
 		MethodAbsScan(OptParser* opt);
 		~MethodAbsScan();
@@ -65,22 +65,22 @@ class MethodAbsScan
 		inline bool                     getFilled(){return drawFilled;};
 		inline TH1F*                    getHCL(){return hCL;};
 		inline TH1F*                    getHCLs(){return hCLs;};
-    inline TH1F*                    getHCLsFreq(){return hCLsFreq;};
-    inline TH1F*                    getHCLsExp(){return hCLsExp;};
-    inline TH1F*                    getHCLsErr1Up(){return hCLsErr1Up;};
-    inline TH1F*                    getHCLsErr1Dn(){return hCLsErr1Dn;};
-    inline TH1F*                    getHCLsErr2Up(){return hCLsErr2Up;};
-    inline TH1F*                    getHCLsErr2Dn(){return hCLsErr2Dn;};
+	    inline TH1F*                    getHCLsFreq(){return hCLsFreq;};
+	    inline TH1F*                    getHCLsExp(){return hCLsExp;};
+	    inline TH1F*                    getHCLsErr1Up(){return hCLsErr1Up;};
+	    inline TH1F*                    getHCLsErr1Dn(){return hCLsErr1Dn;};
+	    inline TH1F*                    getHCLsErr2Up(){return hCLsErr2Up;};
+	    inline TH1F*                    getHCLsErr2Dn(){return hCLsErr2Dn;};
 		inline TH2F*                    getHCL2d(){return hCL2d;};
 		inline TH2F*                    getHCLs2d(){return hCLs2d;};
 		inline TH1F*                    getHchisq(){return hChi2min;};
 		inline TH2F*                    getHchisq2d(){return hChi2min2d;};
 		inline int                      getLineColor(){return lineColor;};
 		inline int                      getLineStyle(){return lineStyle;};
-    inline int                      getLineWidth(){return lineWidth;};
+		inline int                      getLineWidth(){return lineWidth;};
 		inline int                      getFillStyle(){return fillStyle;};
 		inline int                      getFillColor(){return fillColor;};
-    inline float                    getFillTransparency(){return fillTransparency;};
+    	inline float                    getFillTransparency(){return fillTransparency;};
 		inline TString                  getMethodName() const {return methodName;};
 		inline TString                  getName() const {return name;};
 		inline int                      getNObservables(){return w->set(obsName)->getSize();}
@@ -114,7 +114,7 @@ class MethodAbsScan
 		virtual void                    print();
 		void                            printCLintervals(int CLsType, bool calc_expected=false);
 		void                            printLocalMinima();
-    void                            saveLocalMinima(TString fName="");
+    	void                            saveLocalMinima(TString fName="");
 		void                            saveScanner(TString fName="");
 		virtual int                     scan1d();
 		virtual int                     scan2d();
@@ -132,19 +132,19 @@ class MethodAbsScan
 		inline void                     setTextColor(int c){textColor = c;};
 		inline void                     setFillStyle(int c){fillStyle = c;};
 		inline void                     setFillColor(int c){fillColor = c;};
-    inline void                     setFillTransparency(float c){fillTransparency = c;};
+    	inline void                     setFillTransparency(float c){fillTransparency = c;};
 		inline void                     setTitle(TString s){title = s;};
 		void                            setChi2minGlobal(double x);
 		void                            setSolutions(vector<RooSlimFitResult*> s);
 		inline void                     setVerbose(bool yesNo=true){verbose = yesNo;};
-	inline void                     setHCL( TH1F *h ) { hCL = h; };
-	inline void                     setHchisq( TH1F *h ) { hChi2min = h; };
+		inline void                     setHCL( TH1F *h ) { hCL = h; };
+		inline void                     setHchisq( TH1F *h ) { hChi2min = h; };
 		void 							setXscanRange(float min, float max);
 		void 							setYscanRange(float min, float max);
 		void							calcCLintervalsSimple(int CLsType=0, bool calc_expected=false);
 		const std::pair<double, double> getBorders(const TGraph& graph, const double confidence_level, bool qubic=false);
 		const std::pair<double, double> getBorders_CLs(const TGraph& graph, const double confidence_level, bool qubic=false);
-    virtual bool                    checkCLs();
+    	virtual bool                    checkCLs();
 
 		vector<RooSlimFitResult*> allResults;           ///< All fit results we encounter along the scan.
 		vector<RooSlimFitResult*> curveResults;         ///< All fit results of the the points that make it into the 1-CL curve.
@@ -172,7 +172,7 @@ class MethodAbsScan
 		TString obsName;    ///< dataset name of observables, derived from name
 		TString parsName;   ///< set name of physics parameters, derived from name
 		TString thName;     ///< set name of theory parameters, derived from name
-	TString toysName;   ///< set name of parameters to vary in toys
+		TString toysName;   ///< set name of parameters to vary in toys
 		TString scanVar1;   ///< scan parameter
 		TString scanVar2;   ///< second scan parameter if we're scanning 2d
 		int nPoints1d;      ///< number of scan points used by 1d scan
@@ -188,16 +188,17 @@ class MethodAbsScan
 		RooDataSet* startPars;      ///< save the start parameter values before any scan
 		TH1F* hCL;                  ///< 1-CL curve
 		TH1F* hCLs;                 ///< 1-CL curve
-    TH1F* hCLsFreq;             ///< 1-CL curve
-    TH1F* hCLsExp;              ///< 1-CL curve
-    TH1F* hCLsErr1Up;           ///< 1-CL curve
-    TH1F* hCLsErr1Dn;           ///< 1-CL curve
-    TH1F* hCLsErr2Up;           ///< 1-CL curve
-    TH1F* hCLsErr2Dn;           ///< 1-CL curve
+	    TH1F* hCLsFreq;             ///< 1-CL curve
+	    TH1F* hCLsExp;              ///< 1-CL curve
+	    TH1F* hCLsErr1Up;           ///< 1-CL curve
+	    TH1F* hCLsErr1Dn;           ///< 1-CL curve
+	    TH1F* hCLsErr2Up;           ///< 1-CL curve
+	    TH1F* hCLsErr2Dn;           ///< 1-CL curve
 		TH2F* hCL2d;                ///< 1-CL curve
 		TH2F* hCLs2d;               ///< 1-CL curve
 		TH1F* hChi2min;             ///< histogram for the chi2min values before Prob()
 		TH2F* hChi2min2d;           ///< histogram for the chi2min values before Prob()
+		TH1F* hChi2minAsimov;       ///< histogram for the Asimov chi2min values before Prob()
 		double chi2minGlobal;       ///< chi2 value at global minimum
 		double chi2minBkg;       ///< chi2 value at global minimum
 		bool chi2minGlobalFound;    ///< flag to avoid finding minimum twice
@@ -205,9 +206,9 @@ class MethodAbsScan
 		int textColor;              ///< color used for plotted central values
 		int lineStyle;
 		int lineWidth;
-    int fillStyle;
-    int fillColor;
-    float fillTransparency;
+	    int fillStyle;
+	    int fillColor;
+	    float fillTransparency;
 		bool drawFilled;            ///< choose if Histogram is drawn filled or not
 		int drawSolution;           ///< Configure how to draw solutions on the plots.
 		///< 0=don't plot, 1=plot at central value (1d) or markers (2d)

--- a/core/include/MethodDatasetsProbScan.h
+++ b/core/include/MethodDatasetsProbScan.h
@@ -56,6 +56,10 @@ private:
     void                setAndPrintFitStatusConstrainedToys(const ToyTree& toyTree);
     void                setAndPrintFitStatusFreeToys(const ToyTree& toyTree);
     void                sethCLFromProbScanTree();
+
+    RooFitResult*       GlobalBkgAsimovFitResult;
+    double              chi2minGlobalBkgAsimov;
+
 };
 
 #endif

--- a/core/include/PDF_Abs.h
+++ b/core/include/PDF_Abs.h
@@ -151,8 +151,8 @@ class PDF_Abs
 		// The following three members are to gain performance during
 		// toy generation - generating 1000 toys is much faster than 1000 times one toy.
 		int                     nToyObs;        // Number of toy observables to be pregenerated.
-		RooDataSet*             toyObservables; // A dataset holding nToyObs pregenerated bkg only toy observables.
-		RooDataSet*             toyBkgObservables; // A dataset holding nToyObs pregenerated toy observables.
+		RooAbsData*             toyObservables; // A dataset holding nToyObs pregenerated bkg only toy observables.
+		RooAbsData*             toyBkgObservables; // A dataset holding nToyObs pregenerated toy observables.
 		int                     iToyObs;        // Index of next unused set of toy observables.
 		int						gcId;			// ID of this PDF inside a GammaCombo object. Used to refer to this PDF.
 

--- a/core/include/PDF_Datasets.h
+++ b/core/include/PDF_Datasets.h
@@ -112,8 +112,8 @@ public:
     //> name of a snapshot that stores the values of the global observables in data
     const TString         globalObsToySnapshotName = "globalObsToySnapshotName";
     //> name of a snapshot that stores the latest simulated values for the global observables
-   TString         globalObsBkgToySnapshotName = "globalObsBkgToySnapshotName";
-   TString         globalObsBkgAsimovSnapshotName = "globalObsBkgAsimovSnapshotName";
+    TString               globalObsBkgToySnapshotName = "globalObsBkgToySnapshotName";
+    TString               globalObsBkgAsimovSnapshotName = "globalObsBkgAsimovSnapshotName";
     //> name of a snapshot that stores the latest simulated values for the global observables of the bkg-only toy
 
     //debug counters
@@ -121,10 +121,12 @@ public:
     int nsbfits;
 
 protected:
-    void initializeRandomGenerator(int seedShift);
-    RooWorkspace*   wspc;
-    RooDataSet*     data;
-    RooAbsData*     AsimovBkgObservables;
+    void                  initializeRandomGenerator(int seedShift);
+    RooAbsData*           generateBkgAsimovSinglePdf(const RooAbsPdf & pdf, const RooArgSet & allobs,  const RooRealVar & weightVar, RooCategory * channelCat);
+    void                  FillBinsAsimov(const RooAbsPdf & pdf, const RooArgList &obs, RooAbsData & data, int &index,  double &binVolume, int &ibin);
+    RooWorkspace*         wspc;
+    RooDataSet*           data;
+    RooAbsData*           AsimovBkgObservables;
     
     RooAbsReal*     _NLL; // possible pointer to minimization function
     RooAbsPdf*      _constraintPdf;

--- a/core/include/PDF_Datasets.h
+++ b/core/include/PDF_Datasets.h
@@ -27,12 +27,16 @@ public:
     ~PDF_Datasets();
     void                  deleteNLL() {if (_NLL) {delete _NLL; _NLL = NULL;}};
 
-    virtual RooFitResult* fit(RooDataSet* dataToFit);
-    virtual RooFitResult* fitBkg(RooDataSet* dataToFit, TString signalvar);
+    virtual RooFitResult* fit(RooAbsData* dataToFit);
+    virtual RooFitResult* fitBkg(RooAbsData* dataToFit, TString signalvar);
     virtual void          generateToys(int SeedShift = 0);
     virtual void          generateToysGlobalObservables(int SeedShift = 0);
     virtual void          generateBkgToys(int SeedShift = 0, TString signalvar="");
     virtual void          generateBkgToysGlobalObservables(int SeedShift = 0, int index = 0);
+
+    virtual void          generateBkgAsimov(int SeedShift = 0, TString signalvar="");
+    virtual void          generateBkgAsimovGlobalObservables(int SeedShift = 0, int index = 0);
+
 
     void                  initConstraints(const TString& setName);
     void                  initData(const TString& name);
@@ -68,8 +72,9 @@ public:
     TString               getPdfName() {return pdfName;};
     TString               getBkgPdfName() {return pdfBkgName;};
     TString               getMultipdfCatName() {return multipdfCatName;};
-    RooDataSet*           getToyObservables() {return this->toyObservables;};
-    RooDataSet*           getBkgToyObservables() {return toyBkgObservables;};
+    RooAbsData*           getToyObservables() {return this->toyObservables;};
+    RooAbsData*           getBkgToyObservables() {return toyBkgObservables;};
+    RooAbsData*           getBkgAsimovObservables() {return AsimovBkgObservables;};
     RooWorkspace*         getWorkspace() {return wspc;};
     // setters
     inline void           setFitStatus(int stat = 0) {fitStatus = stat;};
@@ -83,8 +88,8 @@ public:
     void                  setNCPU(int n) {NCPU = n;};
     void                  setVarRange(const TString &varName, const TString &rangeName,
                                       const double &rangeMin, const double &rangeMax);
-    void                  setToyData(RooDataSet* ds);
-    void                  setBkgToyData(RooDataSet* ds);
+    void                  setToyData(RooAbsData* ds);
+    void                  setBkgToyData(RooAbsData* ds);
     
     void                  setGlobalObsSnapshotBkgToy(TString snapshotname) {globalObsBkgToySnapshotName = snapshotname;};
 
@@ -108,6 +113,7 @@ public:
     const TString         globalObsToySnapshotName = "globalObsToySnapshotName";
     //> name of a snapshot that stores the latest simulated values for the global observables
    TString         globalObsBkgToySnapshotName = "globalObsBkgToySnapshotName";
+   TString         globalObsBkgAsimovSnapshotName = "globalObsBkgAsimovSnapshotName";
     //> name of a snapshot that stores the latest simulated values for the global observables of the bkg-only toy
 
     //debug counters
@@ -118,6 +124,8 @@ protected:
     void initializeRandomGenerator(int seedShift);
     RooWorkspace*   wspc;
     RooDataSet*     data;
+    RooAbsData*     AsimovBkgObservables;
+    
     RooAbsReal*     _NLL; // possible pointer to minimization function
     RooAbsPdf*      _constraintPdf;
     TString         pdfName; //> name of the pdf in the workspace

--- a/core/include/ToyTree.h
+++ b/core/include/ToyTree.h
@@ -81,6 +81,8 @@ class ToyTree
 		float chi2minBkgToy;	  ///< the chi2 of the fit of the hypothesis value to the bkg toy distribution (for CLs method)
     	float chi2minGlobalBkgToy; ///< the chi2 of the free fit to the bkg only toys
     	float chi2minBkgBkgToy; ///< the chi2 of the bkg fit to the bkg only toys
+		float chi2minGlobalBkgAsimov; ///< the chi2 of the free fit to asimov data (data sets methods)
+		float chi2minAsimov;	///< the chi2 of the scan fit to asimov data (data sets methods)
 		float scanbest;         ///< an alias to the free fit value of the scan variable
 		float scanbesty;        ///< an alias to the free fit value of the scan y variable in 2D scans
     	float scanbestBkg;      ///< an alias to the free fit value of the scan variable on the bkg only toy (for CLs method)

--- a/core/src/MethodAbsScan.cpp
+++ b/core/src/MethodAbsScan.cpp
@@ -71,6 +71,7 @@
 	hCL2d(0),
 	hCLs2d(0),
 	hChi2min(0),
+	hChi2minAsimov(0),
 	hChi2min2d(0),
 	obsDataset(NULL),
 	startPars(0),

--- a/core/src/MethodDatasetsPluginScan.cpp
+++ b/core/src/MethodDatasetsPluginScan.cpp
@@ -1174,7 +1174,7 @@ int MethodDatasetsPluginScan::scan1d(int nRun)
         // pdf->printParameters();
         pdf->generateBkgToys(0,arg->var[0]);
         pdf->generateBkgToysGlobalObservables(0,j);
-        RooDataSet* bkgOnlyToy = pdf->getBkgToyObservables();
+        RooAbsData* bkgOnlyToy = pdf->getBkgToyObservables();
         cls_bkgOnlyToys.push_back( (RooDataSet*)bkgOnlyToy->Clone() ); // clone required because of deleteToys() call at end of loop
         bkgOnlyGlobObsSnaphots.push_back(pdf->globalObsBkgToySnapshotName);
         pdf->setToyData( bkgOnlyToy );

--- a/core/src/MethodDatasetsProbScan.cpp
+++ b/core/src/MethodDatasetsProbScan.cpp
@@ -90,6 +90,20 @@ void MethodDatasetsProbScan::initScan() {
     if (hCLs) delete hCLs;
     hCLs = new TH1F("hCLs" + getUniqueRootName(), "hCLs" + pdf->getPdfName(), nPoints1d, min1, max1);
 
+    if ( hChi2minAsimov ) delete hChi2minAsimov;
+    hChi2minAsimov = new TH1F("hChi2minAsimov" + getUniqueRootName(), "hChi2minAsimov" + pdf->getPdfName(), nPoints1d, min1, max1);
+    if (hCLsExp) delete hCLsExp;
+    hCLsExp = new TH1F("hCLsExp" + getUniqueRootName(), "hCLsExp" + pdf->getPdfName(), nPoints1d, min1, max1);
+    if (hCLsErr1Dn) delete hCLsErr1Dn;
+    hCLsErr1Dn = new TH1F("hCLsErr1Dn" + getUniqueRootName(), "hCLsErr1Dn" + pdf->getPdfName(), nPoints1d, min1, max1);
+    if (hCLsErr1Up) delete hCLsErr1Up;
+    hCLsErr1Up = new TH1F("hCLsErr1Up" + getUniqueRootName(), "hCLsErr1Up" + pdf->getPdfName(), nPoints1d, min1, max1);
+    if (hCLsErr2Dn) delete hCLsErr2Dn;
+    hCLsErr2Dn = new TH1F("hCLsErr2Dn" + getUniqueRootName(), "hCLsErr2Dn" + pdf->getPdfName(), nPoints1d, min1, max1);
+    if (hCLsErr2Up) delete hCLsErr2Up;
+    hCLsErr2Up = new TH1F("hCLsErr2Up" + getUniqueRootName(), "hCLsErr2Up" + pdf->getPdfName(), nPoints1d, min1, max1);
+
+
 
     // fill the chi2 histogram with very unlikely values such
     // that inside scan1d() the if clauses work correctly
@@ -191,7 +205,33 @@ void MethodDatasetsProbScan::initScan() {
     //     std::cout << "=============== Bkg minimum (2*-Log(Likelihood)) is: 2*" << bkgOnlyFitResult->minNll() << " = " << chi2minBkg << endl;
     //     w->var(scanVar1)->setConstant(false);
     // }
+    if (arg->cls.size()!=0){
+        // generate the asimov
+        Utils::setParameters(w,bkgOnlyFitResult); //set parameters to bkg fit to receive a bkg-only asimov
+        // pdf->printParameters();
+        pdf->generateBkgAsimov(0,arg->var[0]);
+        pdf->generateBkgAsimovGlobalObservables(0,0);
+        RooAbsData* bkgOnlyAsimov = pdf->getBkgAsimovObservables();
+        pdf->setToyData( bkgOnlyAsimov );
 
+        // Do a global fit to bkg-only asimov
+        // ToDo: do I need a bkg-only fit for the CLs method as well? In theory should give the same result
+        w->var(scanVar1)->setConstant(false);
+        if (!w->loadSnapshot(pdf->globalObsBkgAsimovSnapshotName)) {
+            std::cout << "FATAL in MethodDatasetsProbScan::initScan() - No snapshot globalObsAsimovToySnapshotName found!\n" << std::endl;
+            exit(EXIT_FAILURE);
+        };
+        // then, fit the pdf while passing it the simulated toy dataset
+        GlobalBkgAsimovFitResult = pdf->fit(pdf->getBkgAsimovObservables());
+        chi2minGlobalBkgAsimov = 2 * pdf->getMinNll();
+
+        //reset parameters and global observables
+        Utils::setParameters(w,globalMin);
+        if (!w->loadSnapshot(pdf->globalObsDataSnapshotName)) {
+            std::cout << "FATAL in MethodDatasetsProbScan::initScan() - No snapshot globalObsToySnapshotName found!\n" << std::endl;
+            exit(EXIT_FAILURE);
+        }
+    }
 
     if (arg->debug) {
         std::cout << "DEBUG in MethodDatasetsProbScan::initScan() - Scan initialized successfully!\n" << std::endl;
@@ -254,6 +294,19 @@ void MethodDatasetsProbScan::sethCLFromProbScanTree() {
     delete hCLs;
     this->hCLs = new TH1F("hCLs", "hCLs", this->probScanTree->getScanpointN(), this->probScanTree->getScanpointMin() - halfBinWidth, this->probScanTree->getScanpointMax() + halfBinWidth);
     if (arg->debug) printf("DEBUG %i %f %f %f\n", this->probScanTree->getScanpointN(), this->probScanTree->getScanpointMin() - halfBinWidth, this->probScanTree->getScanpointMax() + halfBinWidth, halfBinWidth);
+
+    this->hCLsExp = new TH1F("hCLsExp", "hCLsExp", this->probScanTree->getScanpointN(), this->probScanTree->getScanpointMin() - halfBinWidth, this->probScanTree->getScanpointMax() + halfBinWidth);
+    if (arg->debug) printf("DEBUG %i %f %f %f\n", this->probScanTree->getScanpointN(), this->probScanTree->getScanpointMin() - halfBinWidth, this->probScanTree->getScanpointMax() + halfBinWidth, halfBinWidth);
+    this->hCLsErr1Up = new TH1F("hCLsErr1Up", "hCLsErr1Up", this->probScanTree->getScanpointN(), this->probScanTree->getScanpointMin() - halfBinWidth, this->probScanTree->getScanpointMax() + halfBinWidth);
+    if (arg->debug) printf("DEBUG %i %f %f %f\n", this->probScanTree->getScanpointN(), this->probScanTree->getScanpointMin() - halfBinWidth, this->probScanTree->getScanpointMax() + halfBinWidth, halfBinWidth);
+    this->hCLsErr1Dn = new TH1F("hCLsErr1Dn", "hCLsErr1Dn", this->probScanTree->getScanpointN(), this->probScanTree->getScanpointMin() - halfBinWidth, this->probScanTree->getScanpointMax() + halfBinWidth);
+    if (arg->debug) printf("DEBUG %i %f %f %f\n", this->probScanTree->getScanpointN(), this->probScanTree->getScanpointMin() - halfBinWidth, this->probScanTree->getScanpointMax() + halfBinWidth, halfBinWidth);
+    this->hCLsErr2Up = new TH1F("hCLsErr2Up", "hCLsErr2Up", this->probScanTree->getScanpointN(), this->probScanTree->getScanpointMin() - halfBinWidth, this->probScanTree->getScanpointMax() + halfBinWidth);
+    if (arg->debug) printf("DEBUG %i %f %f %f\n", this->probScanTree->getScanpointN(), this->probScanTree->getScanpointMin() - halfBinWidth, this->probScanTree->getScanpointMax() + halfBinWidth, halfBinWidth);
+    this->hCLsErr2Dn = new TH1F("hCLsErr2Dn", "hCLsErr2Dn", this->probScanTree->getScanpointN(), this->probScanTree->getScanpointMin() - halfBinWidth, this->probScanTree->getScanpointMax() + halfBinWidth);
+    if (arg->debug) printf("DEBUG %i %f %f %f\n", this->probScanTree->getScanpointN(), this->probScanTree->getScanpointMin() - halfBinWidth, this->probScanTree->getScanpointMax() + halfBinWidth, halfBinWidth);
+
+
     Long64_t nentries     = this->probScanTree->GetEntries();
     this->probScanTree->activateAllBranches();
     // this->probScanTree->a - DATASETSctivateCoreBranchesOnly(); //< speeds up the event loop
@@ -263,13 +316,13 @@ void MethodDatasetsProbScan::sethCLFromProbScanTree() {
         this->probScanTree->GetEntry(i);
 
         double deltaChi2 = probScanTree->chi2min - probScanTree->chi2minGlobal;
-				double oneMinusCL = TMath::Prob( deltaChi2, 1);
-				// save the value and corresponding fit result
-				// but only if an improvement
-				if ( hCL->GetBinContent(hCL->FindBin( probScanTree->scanpoint ) ) <= oneMinusCL ) {
-					hCL->SetBinContent( hCL->FindBin( probScanTree->scanpoint ) , oneMinusCL );
-					hChi2min->SetBinContent( hCL->FindBin( probScanTree->scanpoint ), probScanTree->chi2min );
-				}
+		double oneMinusCL = TMath::Prob( deltaChi2, 1);
+		// save the value and corresponding fit result
+		// but only if an improvement
+		if ( hCL->GetBinContent(hCL->FindBin( probScanTree->scanpoint ) ) <= oneMinusCL ) {
+			hCL->SetBinContent( hCL->FindBin( probScanTree->scanpoint ) , oneMinusCL );
+			hChi2min->SetBinContent( hCL->FindBin( probScanTree->scanpoint ), probScanTree->chi2min );
+		}
         // and whilst we here do the same relative to the background only hypothesis (i.e. for CLs method)
         double deltaChi2Bkg  = probScanTree->chi2min - probScanTree->chi2minBkg;
         //double oneMinusCLBkg = TMath::Prob( deltaChi2Bkg, 1);
@@ -277,6 +330,8 @@ void MethodDatasetsProbScan::sethCLFromProbScanTree() {
         if ( hCLs->GetBinCenter( hCLs->FindBin( probScanTree->scanpoint ) ) <= oneMinusCLBkg ) {
             hCLs->SetBinContent( hCLs->FindBin( probScanTree->scanpoint ), oneMinusCLBkg );
         }
+
+        hChi2minAsimov->SetBinContent(hChi2minAsimov->FindBin(probScanTree->scanpoint), probScanTree->chi2minAsimov);
     }
     // if only the plot method then set the global and bkg minimums from the file
     if ( arg->isAction("plot") ) {
@@ -451,6 +506,33 @@ int MethodDatasetsProbScan::scan1d(bool fast, bool reverse)
         this->probScanTree->covQualScanData   = result->covQual();
         this->probScanTree->scanbest  = freeDataFitValue;
 
+        //Now fit and save the Asimov data (if existing) for the "fast" expected cls/banana plots
+
+        if(arg->cls.size()>0){
+            if (!w->loadSnapshot(pdf->globalObsBkgAsimovSnapshotName)) {
+                std::cout << "FATAL in MethodDatasetsProbScan::scan1d() - No snapshot globalObsAsimovToySnapshotName found!\n" << std::endl;
+                exit(EXIT_FAILURE);
+            };
+            // then, fit the pdf while passing it the simulated toy dataset
+            RooFitResult *asimov_result = pdf->fit(pdf->getBkgAsimovObservables());
+            double chi2minBkgAsimov = 2 * pdf->getMinNll();
+
+            //reset parameters and global observables
+            Utils::setParameters(w,globalMin);
+            if (!w->loadSnapshot(pdf->globalObsDataSnapshotName)) {
+                std::cout << "FATAL in MethodDatasetsProbScan::scan1d() - No snapshot globalObsToySnapshotName found!\n" << std::endl;
+                exit(EXIT_FAILURE);
+            }
+            this->probScanTree->chi2minAsimov = chi2minBkgAsimov;
+            // this->probScanTree->covQualScanAsimov = asimov_result->covQual();
+            // this->probScanTree->scanbestAsimov = //don't think I'll need it? Should in theory be always exactly zero for bkg-only Asimovs...
+            this->probScanTree->chi2minGlobalBkgAsimov = chi2minGlobalBkgAsimov;
+            // probScanTree->covQualFreeAsimov = GlobalBkgAsimovFitResult->covQual();
+            // probScanTree->statusFreeAsimov = GlobalBkgAsimovFitResult->status();
+        }
+
+
+
         // After doing the fit with the parameter of interest constrained to the scanpoint,
         // we are now saving the fit values of the nuisance parameters. These values will be
         // used to generate toys according to the PLUGIN method.
@@ -518,18 +600,36 @@ int MethodDatasetsProbScan::computeCLvalues(){
     std::cout << "Using "<< arg->teststatistic <<"-sided test statistic" << std::endl;
     float bestfitpoint = ((RooRealVar*) globalMin->floatParsFinal().find(scanVar1))->getVal();
     float bestfitpointerr = ((RooRealVar*) globalMin->floatParsFinal().find(scanVar1))->getError();
+    float bestfitpointAsimov = 0.;
+    float bestfitpointerrAsimov = 0.;
+    
+    if(arg->cls.size()>0){
+        float bestfitpointAsimov = ((RooRealVar*) GlobalBkgAsimovFitResult->floatParsFinal().find(scanVar1))->getVal();
+        float bestfitpointerrAsimov = ((RooRealVar*) GlobalBkgAsimovFitResult->floatParsFinal().find(scanVar1))->getError();
+    }
 
     for (int k=1; k<=hCL->GetNbinsX(); k++){
         float scanvalue=hChi2min->GetBinCenter( k);
         float teststat_measured = hChi2min->GetBinContent(k) - chi2minGlobal;
+        float teststat_asimov = hChi2minAsimov->GetBinContent(k) - chi2minGlobalBkgAsimov;
         float CLb = 1. - (normal_cdf(TMath::Sqrt(teststat_measured) + ((scanvalue - 0.)/bestfitpointerr)) + normal_cdf(TMath::Sqrt(teststat_measured) - ((scanvalue - 0.)/bestfitpointerr)) - 1.);
         if (arg->teststatistic ==1){ // use one-sided test statistic
             teststat_measured = bestfitpoint <= scanvalue ? teststat_measured : 0.; // if mu < muhat then q_mu = 0
+            teststat_asimov = bestfitpointAsimov <= scanvalue ? teststat_asimov : 0.; // if mu < muhat then q_mu = 0
             hCL->SetBinContent(k,1. - normal_cdf(TMath::Sqrt(teststat_measured)));
             // if (scanvalue < bestfitpoint) hCL->SetBinContent(k,1.0);    // should not be here, but looks ugly if solution is drawn as p=1
             CLb = 1. - normal_cdf(TMath::Sqrt(teststat_measured) - ((scanvalue - 0.)/bestfitpointerr));
         }
         hCLs->SetBinContent(k,min(1.,hCL->GetBinContent(k)/CLb));
+
+        if(arg->cls.size()>0){
+            double sigma_asimov = TMath::Sqrt(scanvalue*scanvalue/teststat_asimov);
+            hCLsExp->SetBinContent(k,normal_cdf(TMath::Sqrt(teststat_asimov))); //scanvalue/sigma_asimov
+            hCLsErr1Dn->SetBinContent(k,normal_cdf(TMath::Sqrt(teststat_asimov)+1)); //scanvalue/sigma_asimov
+            hCLsErr1Up->SetBinContent(k,normal_cdf(TMath::Sqrt(teststat_asimov)-1)); //scanvalue/sigma_asimov
+            hCLsErr2Dn->SetBinContent(k,normal_cdf(TMath::Sqrt(teststat_asimov)+2)); //scanvalue/sigma_asimov
+            hCLsErr2Up->SetBinContent(k,normal_cdf(TMath::Sqrt(teststat_asimov)-2)); //scanvalue/sigma_asimov
+        }
     }
     return 0;
 }

--- a/core/src/PDF_Datasets.cpp
+++ b/core/src/PDF_Datasets.cpp
@@ -9,6 +9,7 @@
 
 #include "PDF_Datasets.h"
 #include "TIterator.h"
+#include "RooSimultaneous.h"
 
 PDF_Datasets::PDF_Datasets(RooWorkspace* w, int nObs, OptParser* opt)
     : PDF_Abs(nObs) {
@@ -133,7 +134,7 @@ void  PDF_Datasets::initParameters(const vector<TString>& parNames) {
     Utils::fillArgList(parameters, wspc, parNames);
     wspc->defineSet(parName, *parameters);//, RooFit::Silence());
     areParsSet = true;
-    if (arg->debug) std::cout << "DEBUG in PDF_Generic_Abs::initParameters --pars filled" << std::endl;
+    // std::cout << "DEBUG in PDF_Generic_Abs::initParameters --pars filled" << std::endl;
 };
 
 void  PDF_Datasets::initParameters() {
@@ -312,6 +313,7 @@ void  PDF_Datasets::generateBkgToysGlobalObservables(int SeedShift, int index) {
     // take a snapshot of the global variables in the workspace so they can be loaded later
     globalObsBkgToySnapshotName = index_string;
     wspc->saveSnapshot(globalObsBkgToySnapshotName, *wspc->set(globalObsName));
+    return;
 };
 
 
@@ -333,6 +335,7 @@ void  PDF_Datasets::generateBkgAsimovGlobalObservables(int SeedShift, int index)
     // take a snapshot of the global variables in the workspace so they can be loaded later
     globalObsBkgAsimovSnapshotName = index_string;
     wspc->saveSnapshot(globalObsBkgAsimovSnapshotName, *wspc->set(globalObsName));
+    return;
 };
 
 
@@ -351,6 +354,7 @@ void  PDF_Datasets::generateToysGlobalObservables(int SeedShift) {
 
     // take a snapshot of the global variables in the workspace so they can be loaded later
     wspc->saveSnapshot(globalObsToySnapshotName, *wspc->set(globalObsName));
+    return;
 };
 
 
@@ -566,6 +570,7 @@ void   PDF_Datasets::generateToys(int SeedShift) {
     // if(this->toyObservables) delete this->toyObservables;
     this->toyObservables  = toys;
     this->isToyDataSet    = kTRUE;
+    return;
 };
 
 void   PDF_Datasets::generateBkgToys(int SeedShift, TString signalvar) {
@@ -602,48 +607,215 @@ void   PDF_Datasets::generateBkgToys(int SeedShift, TString signalvar) {
         getWorkspace()->var(signalvar)->setConstant(isconst);    
     }
     this->toyBkgObservables  = toys;
+    return;
 };
 
 
-//ToDo: make proper Asimov sample
+////////////////////////////////////////////////////////////////////////////////////
+// generate a bkg asimov data set
+// Idea: approximate the unbinned data set from a binning the pdf (how many bins is "fine"?),
+// where for each bin a point is added to the asimov data set
+// with a weight that corresponds to the expected number of events in that bin. -> implementation taken from RooStats
 void   PDF_Datasets::generateBkgAsimov(int SeedShift, TString signalvar) {
 
     initializeRandomGenerator(SeedShift);
 
-    // if(!isBkgPdfSet){
-    //     std::cout << "WRANING in PDF_Datasets::generateBkgToys: No bkg pdf given." << std::endl;
-    //     // exit(EXIT_FAILURE);
-    // }
-    // std::cout << "WARNING in PDF_Datasets::generateBkgToys -- Fitting bkg model as sig+bkg model with " << signalvar << " to zero!" << std::endl;
-    RooDataSet* toys;
+    double parvalue = getWorkspace()->var(signalvar)->getVal();
+    bool isconst = getWorkspace()->var(signalvar)->isConstant();
+    getWorkspace()->var(signalvar)->setVal(0.0);
+    getWorkspace()->var(signalvar)->setConstant(true);
+
+    RooAbsData* toys;
+
+    RooAbsPdf* bestpdf = NULL;
     if (isBkgMultipdfSet) {
-        toys = multipdfBkg->getPdf(bestIndexBkg)->generate(*observables, wspc->data(dataName)->numEntries(),false,true,"",false,true);
+        bestpdf = multipdfBkg->getPdf(bestIndexBkg);
     }
     else if(pdfBkg && !isMultipdfSet){
-        toys = pdfBkg->generate(*observables, wspc->data(dataName)->numEntries(),false,true,"",false,true);
+        bestpdf = pdfBkg;
     }
     else
     {
-        double parvalue = getWorkspace()->var(signalvar)->getVal();
-        bool isconst = getWorkspace()->var(signalvar)->isConstant();
-        getWorkspace()->var(signalvar)->setVal(0.0);
-        getWorkspace()->var(signalvar)->setConstant(true);
-        // RooDataSet* toys = pdfBkg->generate(*observables, RooFit::NumEvents(wspc->data(dataName)->numEntries()), RooFit::Extended(kTRUE));
-        // RooDataSet* toys = pdf->generate(*observables, RooFit::NumEvents(wspc->data(dataName)->numEntries()), RooFit::Extended(kTRUE));
         if (isMultipdfSet) {
-            toys = multipdf->getPdf(bestIndexBkg)->generate(*observables, wspc->data(dataName)->numEntries(),false,true,"",false,true);
+            bestpdf = multipdf->getPdf(bestIndexBkg);
         }
         else {
-            toys = pdf->generate(*observables, wspc->data(dataName)->numEntries(),false,true,"",false,true);
+            bestpdf = pdf;
         }
-        getWorkspace()->var(signalvar)->setVal(parvalue);
-        getWorkspace()->var(signalvar)->setConstant(isconst);    
     }
+
+    unique_ptr<RooRealVar> weightVar (new RooRealVar("binWeightAsimov", "binWeightAsimov", 1., 0., 1.E30 ));
+
+    // check whether simultaneous or not
+    const RooSimultaneous* simPdf = dynamic_cast<const RooSimultaneous*>(bestpdf);
+
+    if(!simPdf){
+    // generate data for non-simultaneous pdf
+        toys = generateBkgAsimovSinglePdf(*bestpdf, *observables, *weightVar, 0);
+    }
+    else{
+        std::map<std::string, RooDataSet*> asimovDataMap;
+        // retrieve category var
+        RooCategory& channelCat = const_cast<RooCategory&>(dynamic_cast<const RooCategory&>(simPdf->indexCat()));
+        int nrIndices = channelCat.numTypes();
+        if( nrIndices == 0 ) {
+            std::cout << "PDF_Datasets::generateBkgAsimov(): Simultaneous pdf does not contain any categories." << endl;
+            assert(0);
+        }
+        // iterate category
+        // for each category generate single pdf
+        for (int i=0;i<nrIndices;i++){
+            channelCat.setIndex(i);
+            // Get pdf associated with state from simpdf
+            RooAbsPdf* pdftmp = simPdf->getPdf(channelCat.getCurrentLabel()) ;
+            assert(pdftmp != 0);
+
+            std::cout << "PDF_Datasets::generateBkgAsimov(): on type " << channelCat.getCurrentLabel() << " " << channelCat.getCurrentIndex() << endl;
+
+            RooAbsData * dataSinglePdf = generateBkgAsimovSinglePdf( *pdftmp, *observables, *weightVar, &channelCat);
+            if (!dataSinglePdf) {
+                std::cout << "PDF_Datasets::generateBkgAsimov(): Error generating an Asimov data set for pdf " << pdftmp->GetName() << endl;
+                assert(0);
+            }
+            if (asimovDataMap.count(string(channelCat.getCurrentLabel())) != 0) {
+                std::cout << "PDF_Datasets::generateBkgAsimov(): The PDF for " << channelCat.getCurrentLabel()
+                << " was already defined. It will be overridden. The faulty category definitions follow:" << endl;
+                channelCat.Print("V");
+            }
+            asimovDataMap[string(channelCat.getCurrentLabel())] = (RooDataSet*) dataSinglePdf;
+
+            cout << "channel: " << channelCat.getCurrentLabel() << ", data: ";
+            dataSinglePdf->Print();
+            cout << endl;
+        }
+
+        RooArgSet obsAndWeight(*observables);
+        obsAndWeight.add(*weightVar);
+
+        RooDataSet* asimovData = new RooDataSet("asimovDataFullModel","asimovDataFullModel",RooArgSet(obsAndWeight),
+                                          RooFit::Index(channelCat),RooFit::Import(asimovDataMap),RooFit::WeightVar(*weightVar));
+
+        for (auto &element : asimovDataMap) {
+            delete element.second;
+        }
+
+        toys = asimovData;
+    }
+
+    // reset signal parameter
+    getWorkspace()->var(signalvar)->setVal(parvalue);
+    getWorkspace()->var(signalvar)->setConstant(isconst);    
+
     this->AsimovBkgObservables  = toys;
+    return;
 };
 
+ ////////////////////////////////////////////////////////////////////////////////
+ /// fill bins by looping recursively on observables, taken from RooStats
+ RooAbsData * PDF_Datasets::generateBkgAsimovSinglePdf(const RooAbsPdf & pdf, const RooArgSet & allobs,  const RooRealVar & weightVar, RooCategory * channelCat) {
+    // Get observables defined by the pdf associated with this state
+    
+    std::unique_ptr<RooArgSet> obs(pdf.getObservables(allobs) );
+
+    RooArgSet obsAndWeight(*obs);
+    obsAndWeight.add(weightVar);
+
+    RooDataSet* asimovData = 0;
+    if (channelCat) {
+        int icat = channelCat->getCurrentIndex();
+        asimovData = new RooDataSet((std::string("AsimovData") + std::to_string(icat)).c_str(),
+            (std::string("combAsimovData") + std::to_string(icat)).c_str(),
+            RooArgSet(obsAndWeight),RooFit::WeightVar(weightVar));
+    }
+    else
+        asimovData = new RooDataSet("AsimovData","AsimovData",RooArgSet(obsAndWeight),RooFit::WeightVar(weightVar));
+
+    RooArgList obsList(*obs);
+    
+    // loop on observables and on the bins
+    // this needs to be in a recursive manner to automatically take into account the (in principle unconstrained) number of observables
+    cout << "PDF_Datasets::generateBkgAsimovSinglePdf(): Generating bkg asimov data for pdf " << pdf.GetName() << endl;
+    cout << "PDF_Datasets::generateBkgAsimovSinglePdf(): list of observables  " << endl;
+    obsList.Print();
+ 
+    int obsIndex = 0;
+    double binVolume = 1;
+    int nbins = 0;
+    FillBinsAsimov(pdf, obsList, *asimovData, obsIndex, binVolume, nbins);
+
+    cout << "PDF_Datasets::generateBkgAsimovSinglePdf(): filled from " << pdf.GetName() << "   " << nbins << " nbins " << " volume is " << binVolume << endl;
+ 
+    asimovData->Print();
+
+    if( TMath::IsNaN(asimovData->sumEntries()) ){
+      cout << "sum entries is nan"<<endl;
+      assert(0);
+      delete asimovData;
+      asimovData = 0;
+    } 
+    return asimovData;
+
+ };
 
 
+
+ ////////////////////////////////////////////////////////////////////////////////
+ /// fill bins by looping recursively on observables, taken from RooStats
+ void PDF_Datasets::FillBinsAsimov(const RooAbsPdf & pdf, const RooArgList &obs, RooAbsData & data, int &index,  double &binVolume, int &ibin) {
+    
+    RooRealVar * v = dynamic_cast<RooRealVar*>( &(obs[index]) );
+    if (!v) return;
+  
+    v->Print("v");
+
+    RooArgSet obstmp(obs);
+    double expectedEvents = pdf.expectedEvents(obstmp);
+
+    std::cout << "PDF_Datasets::FillBinsAsimov(): expected events = " << expectedEvents << std::endl;
+    std::cout << "PDF_Datasets::FillBinsAsimov(): looping on observable " << v->GetName() << endl;
+
+    std::cout << v->GetName() << " has " << v->getBins() << " bins." << std::endl;
+    for (int i = 0; i < v->getBins(); ++i) {
+       v->setBin(i);
+       if (index < obs.getSize() -1) {
+          index++;  // increase index
+          double prevBinVolume = binVolume;
+          binVolume *= v->getBinWidth(i); // increase bin volume
+          FillBinsAsimov(pdf, obs, data, index,  binVolume, ibin);
+          index--; // decrease index
+          binVolume = prevBinVolume; // decrease also bin volume
+       }
+       else {
+          // this is now a new bin - compute the pdf in this bin
+          double totBinVolume = binVolume * v->getBinWidth(i);
+          double fval = pdf.getVal(&obstmp)*totBinVolume;
+  
+          std::cout << "PDF_Datasets::FillBinsAsimov(): pdf value in the bin " << fval << " bin volume = " << totBinVolume << "   " << fval*expectedEvents << std::endl;
+          if (fval*expectedEvents <= 0)
+          {
+             if (fval*expectedEvents < 0)
+                cout << "PDF_Datasets::FillBinsAsimov(): WARNING::Detected a bin with negative expected events! Please check your inputs." << endl;
+             else
+                cout << "PDF_Datasets::FillBinsAsimov(): WARNING::Detected a bin with zero expected events- skip it" << endl;
+          }
+          // have a cut off for overflows ??
+          else
+             data.add(obs, fval*expectedEvents);
+  
+          cout << "bin " << ibin << "\t";
+          for (int j=0; j < obs.getSize(); ++j) { cout << "  " <<  ((RooRealVar&) obs[j]).getVal(); }
+          cout << " w = " << fval*expectedEvents;
+          cout << endl;
+
+          ibin++;
+       }
+    }
+    //reset bin values
+    cout << "ending loop on .. " << v->GetName() << endl;
+
+    v->setBin(0);
+  
+ };
 
 
 /*! \brief Initializes the random generator

--- a/core/src/ToyTree.cpp
+++ b/core/src/ToyTree.cpp
@@ -154,6 +154,8 @@ void ToyTree::init()
 	t->Branch("chi2minBkgBkgToy", 	 &chi2minBkgBkgToy,    "chi2minBkgBkgToy/F");
 	t->Branch("chi2minBkg",    	     &chi2minBkg,		   "chi2minBkg/F");
 	t->Branch("chi2minBkgToy", 	     &chi2minBkgToy,       "chi2minBkgToy/F");
+	t->Branch("chi2minGlobalBkgAsimov",&chi2minGlobalBkgAsimov,       "chi2minGlobalBkgAsimov/F");
+	t->Branch("chi2minAsimov", 	     &chi2minAsimov,       "chi2minAsimov/F");
 	t->Branch("covQualFree",         &covQualFree,         "covQualFree/F");
 	t->Branch("covQualScan",         &covQualScan,         "covQualScan/F");
 	t->Branch("covQualFreeBkg",      &covQualFreeBkg,      "covQualFreeBkg/F");
@@ -244,6 +246,8 @@ void ToyTree::open()
 	if(branches->FindObject("chi2minBkgBkgToy"	 )) t->SetBranchAddress("chi2minBkgBkgToy",	  &chi2minBkgBkgToy);
 	if(branches->FindObject("chi2minBkg"      	 )) t->SetBranchAddress("chi2minBkg",      	  &chi2minBkg);
 	if(branches->FindObject("chi2minBkgToy"   	 )) t->SetBranchAddress("chi2minBkgToy",   	  &chi2minBkgToy);
+	if(branches->FindObject("chi2minGlobalBkgAsimov"   	 )) t->SetBranchAddress("chi2minGlobalBkgAsimov",   	  &chi2minGlobalBkgAsimov);
+	if(branches->FindObject("chi2minAsimov"   	 )) t->SetBranchAddress("chi2minAsimov",   	  &chi2minAsimov);
 	if(branches->FindObject("covQualFree"        )) t->SetBranchAddress("covQualFree",        &covQualFree);
 	if(branches->FindObject("covQualScan"        )) t->SetBranchAddress("covQualScan",        &covQualScan);
 	if(branches->FindObject("covQualScanData"    )) t->SetBranchAddress("covQualScanData",    &covQualScanData);


### PR DESCRIPTION
I started to implement the expected cls bands with the asymptotic formulae based on asimov data sets, such that the cls bands can be obtained also without running the plugin method (subject to the assumption of being in an asymptotic regime).
The asimov data generation is pretty much copied from RooStats. The method used for unbinned data is to take the typical binning scheme (normally 100 bins) and for each bin generate a new point with a weight that corresponds to the expected yield at that point. Whether that is the proper and most unbiased thing to do, I don't know.
What remains to be done
- [x]  implement a version that works for the tutorial data sets case one-sided test statistic
- [ ]  implement a working version for the two-sided case
- [ ]  test against the plugin method with high statistics (validates the asimov set as well, possibly the asimov test can be done standalone separately)
- [ ] test with a simultaneous pdf
- [ ] port to the gammacombo combiner part (that actually already has an implementation for asimov data)
- [ ] test onesided and twosided teststat on combiner part