### PR TITLE
Fix for ROOT>=6.28 - cannot assign with RooAbsPdf

### DIFF
--- a/core/include/RooBinned2DBicubicBase.h
+++ b/core/include/RooBinned2DBicubicBase.h
@@ -73,8 +73,8 @@ class RooBinned2DBicubicBase : public BASE
         const RooBinned2DBicubicBase<BASE>& other, const
         char* name = 0);
     /// assignment operator
-    RooBinned2DBicubicBase<BASE>& operator=(
-        const RooBinned2DBicubicBase<BASE>& other);
+    /*RooBinned2DBicubicBase<BASE>& operator=(
+        const RooBinned2DBicubicBase<BASE>& other);*/
     /// clone method
     virtual RooBinned2DBicubicBase<BASE>* clone(
         const char* newname = 0) const;

--- a/core/src/RooBinned2DBicubicBase.cpp
+++ b/core/src/RooBinned2DBicubicBase.cpp
@@ -35,7 +35,7 @@ RooBinned2DBicubicBase<BASE>::RooBinned2DBicubicBase(
     coeffs(other.coeffs)
 { }
 
-template<class BASE>
+/*template<class BASE>
 RooBinned2DBicubicBase<BASE>& RooBinned2DBicubicBase<BASE>::operator=(
     const RooBinned2DBicubicBase<BASE>& other)
 {
@@ -53,7 +53,7 @@ RooBinned2DBicubicBase<BASE>& RooBinned2DBicubicBase<BASE>::operator=(
     ymax = other.ymax;
     coeffs = other.coeffs;
     return *this;
-}
+}*/
 
 template<class BASE>
 inline double RooBinned2DBicubicBase<BASE>::histcont(

--- a/scripts/setup_lxplus.sh
+++ b/scripts/setup_lxplus.sh
@@ -1,8 +1,9 @@
 # python2
 #source /cvmfs/sft.cern.ch/lcg/releases/LCG_98/ROOT/v6.22.00/x86_64-centos7-gcc10-opt/ROOT-env.sh
 # python3
-source /cvmfs/sft.cern.ch/lcg/releases/LCG_98python3/ROOT/v6.22.00/x86_64-centos7-gcc10-opt/ROOT-env.sh
-source /cvmfs/sft.cern.ch/lcg/releases/LCG_98/gcc/10.1.0/x86_64-centos7/setup.sh
-export LD_LIBRARY_PATH=$PWD/build:$LD_LIBRARY_PATH
-export LD_LIBRARY_PATH=$PWD/build/gammacombo:$LD_LIBRARY_PATH
-export LD_LIBRARY_PATH=$PWD/build/biggammacombo:$LD_LIBRARY_PATH
+# source /cvmfs/sft.cern.ch/lcg/releases/LCG_98python3/ROOT/v6.22.00/x86_64-centos7-gcc10-opt/ROOT-env.sh
+# source /cvmfs/sft.cern.ch/lcg/releases/LCG_98/gcc/10.1.0/x86_64-centos7/setup.sh
+# export LD_LIBRARY_PATH=$PWD/build:$LD_LIBRARY_PATH
+# export LD_LIBRARY_PATH=$PWD/build/gammacombo:$LD_LIBRARY_PATH
+# export LD_LIBRARY_PATH=$PWD/build/biggammacombo:$LD_LIBRARY_PATH
+source /cvmfs/sft.cern.ch/lcg/releases/LCG_104/ROOT/6.28.04/x86_64-el9-gcc11-opt/ROOT-env.sh

--- a/scripts/setup_lxplus.sh
+++ b/scripts/setup_lxplus.sh
@@ -1,9 +1,1 @@
-# python2
-#source /cvmfs/sft.cern.ch/lcg/releases/LCG_98/ROOT/v6.22.00/x86_64-centos7-gcc10-opt/ROOT-env.sh
-# python3
-# source /cvmfs/sft.cern.ch/lcg/releases/LCG_98python3/ROOT/v6.22.00/x86_64-centos7-gcc10-opt/ROOT-env.sh
-# source /cvmfs/sft.cern.ch/lcg/releases/LCG_98/gcc/10.1.0/x86_64-centos7/setup.sh
-# export LD_LIBRARY_PATH=$PWD/build:$LD_LIBRARY_PATH
-# export LD_LIBRARY_PATH=$PWD/build/gammacombo:$LD_LIBRARY_PATH
-# export LD_LIBRARY_PATH=$PWD/build/biggammacombo:$LD_LIBRARY_PATH
 source /cvmfs/sft.cern.ch/lcg/releases/LCG_104/ROOT/6.28.04/x86_64-el9-gcc11-opt/ROOT-env.sh


### PR DESCRIPTION
This should resolve some issues (at least for ROOT 6.28). Will then make a release version.