### PR TITLE
Resurrect the tutorial

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,7 +48,7 @@ jobs:
         ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
 
     - name: Publish output (if not a fork PR)
-      if: ${{ github.repository_owner == 'gammacombo' && (github.event.pull_request == null || github.event.pull_request.head.repo.fork == false) }} 
+      if: ${{ github.repository_owner == 'gammacombo' && (github.event.pull_request == null || github.event.pull_request.head.repo.fork == false) }}
       run: |
         git clone git@github.com:gammacombo/gammacombo.github.io.git
         cp ci_logs/* gammacombo.github.io/assets/images/ci/

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,7 +43,7 @@ jobs:
 
     - name: Configure ssh keys
       if: ${{ github.repository_owner == 'gammacombo' && (github.event.pull_request == null || github.event.pull_request.head.repo.fork == false) }}
-      uses: webfactory/ssh-agent@v0
+      uses: webfactory/ssh-agent@v0.9.0
       with:
         ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,12 +44,12 @@ jobs:
     - name: Publish output (if not a fork PR)
       if: ${{ github.repository_owner == 'gammacombo' && (github.event.pull_request == null || github.event.pull_request.head.repo.fork == false) }}
       env:
-        GH_PAT: ${{ secrets.GH_PAT }}
+        GC_PAT: ${{ secrets.GC_PAT }}
       run: |
         git config --global user.email "gcci@cern.ch"
         git config --global user.name "gammacombo"
 
-        git clone https://gammacombo:${GH_PAT}@github.com/gammacombo/gammacombo.github.io.git
+        git clone https://gammacombo:${GC_PAT}@github.com/gammacombo/gammacombo.github.io.git
         cp ci_logs/* gammacombo.github.io/assets/images/ci/
         cd gammacombo.github.io
         touch ci.html

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,22 +41,22 @@ jobs:
         docker cp gcrun:/code/tutorial/ci_logs ./ci_logs
         docker rm gcrun
 
-    - name: Publish output (if not a fork PR)
-      if: ${{ github.repository_owner == 'gammacombo' && (github.event.pull_request == null || github.event.pull_request.head.repo.fork == false) }}
-      env:
-        GC_PAT: ${{ secrets.GC_PAT }}
-      run: |
-        git config --global user.email "gcci@cern.ch"
-        git config --global user.name "gammacombo"
-
-        git clone https://gammacombo:${GC_PAT}@github.com/gammacombo/gammacombo.github.io.git
-        cp ci_logs/* gammacombo.github.io/assets/images/ci/
-        cd gammacombo.github.io
-        touch ci.html
-        git add ci.html assets/images/ci/*
-        git commit -m "CI test results" || echo "No changes to commit"
-        git push origin master
-
-    - name: Print Info
-      if: ${{ github.repository_owner == 'gammacombo' && (github.event.pull_request == null || github.event.pull_request.head.repo.fork == false) }}
-      run: echo "Success. Check your CI tests at https://gammacombo.github.io/ci.html"
+    # - name: Publish output (if not a fork PR)
+    #   if: ${{ github.repository_owner == 'gammacombo' && (github.event.pull_request == null || github.event.pull_request.head.repo.fork == false) }}
+    #   env:
+    #     GC_PAT: ${{ secrets.GC_PAT }}
+    #   run: |
+    #     git config --global user.email "gcci@cern.ch"
+    #     git config --global user.name "gammacombo"
+    #
+    #     git clone https://gammacombo:${GC_PAT}@github.com/gammacombo/gammacombo.github.io.git
+    #     cp ci_logs/* gammacombo.github.io/assets/images/ci/
+    #     cd gammacombo.github.io
+    #     touch ci.html
+    #     git add ci.html assets/images/ci/*
+    #     git commit -m "CI test results" || echo "No changes to commit"
+    #     git push origin master
+    #
+    # - name: Print Info
+    #   if: ${{ github.repository_owner == 'gammacombo' && (github.event.pull_request == null || github.event.pull_request.head.repo.fork == false) }}
+    #   run: echo "Success. Check your CI tests at https://gammacombo.github.io/ci.html"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,7 +48,7 @@ jobs:
         ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
 
     - name: Publish output (if not a fork PR)
-      if: ${{ github.repository_owner == 'gammacombo' && github.event.pull_request.head.repo.full_name == github.repository }} 
+      if: ${{ github.repository_owner == 'gammacombo' && github.event.pull_request.head.repo.full_name == github.repository }}
       run: |
         git clone git@github.com:gammacombo/gammacombo.github.io.git
         cp ci_logs/* gammacombo.github.io/assets/images/ci/

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,23 +41,19 @@ jobs:
         docker cp gcrun:/code/tutorial/ci_logs ./ci_logs
         docker rm gcrun
 
-    - name: Configure ssh keys
-      if: ${{ github.repository_owner == 'gammacombo' && (github.event.pull_request == null || github.event.pull_request.head.repo.fork == false) }}
-      uses: webfactory/ssh-agent@v0.9.0
-      with:
-        ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
-
     - name: Publish output (if not a fork PR)
       if: ${{ github.repository_owner == 'gammacombo' && (github.event.pull_request == null || github.event.pull_request.head.repo.fork == false) }}
+      env:
+        GH_PAT: ${{ secrets.GH_PAT }}
       run: |
-        git clone git@github.com:gammacombo/gammacombo.github.io.git
+        git config --global user.email "gcci@cern.ch"
+        git config --global user.name "gammacombo"
+
+        git clone https://gammacombo:${GH_PAT}@github.com/gammacombo/gammacombo.github.io.git
         cp ci_logs/* gammacombo.github.io/assets/images/ci/
         cd gammacombo.github.io
-        git config --local user.email "gcci@cern.ch"
-        git config --local user.name "gammacombo"
         touch ci.html
-        git add ci.html
-        git add assets/images/ci/*
+        git add ci.html assets/images/ci/*
         git commit -m "CI test results" || echo "No changes to commit"
         git push origin master
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,13 +42,13 @@ jobs:
         docker rm gcrun
 
     - name: Configure ssh keys
-      if: ${{ github.repository_owner == 'gammacombo' }}
-      uses: webfactory/ssh-agent@v0.2.0
+      if: ${{ github.repository_owner == 'gammacombo' && (github.event.pull_request == null || github.event.pull_request.head.repo.fork == false) }}
+      uses: webfactory/ssh-agent@v0
       with:
         ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
 
     - name: Publish output (if not a fork PR)
-      if: ${{ github.repository_owner == 'gammacombo' && github.event.pull_request.head.repo.full_name == github.repository }}
+      if: ${{ github.repository_owner == 'gammacombo' && (github.event.pull_request == null || github.event.pull_request.head.repo.fork == false) }} 
       run: |
         git clone git@github.com:gammacombo/gammacombo.github.io.git
         cp ci_logs/* gammacombo.github.io/assets/images/ci/
@@ -58,9 +58,9 @@ jobs:
         touch ci.html
         git add ci.html
         git add assets/images/ci/*
-        git commit -m "CI test results"
+        git commit -m "CI test results" || echo "No changes to commit"
         git push origin master
 
     - name: Print Info
-      if: ${{ github.repository_owner == 'gammacombo' }}
+      if: ${{ github.repository_owner == 'gammacombo' && (github.event.pull_request == null || github.event.pull_request.head.repo.fork == false) }}
       run: echo "Success. Check your CI tests at https://gammacombo.github.io/ci.html"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,13 +42,13 @@ jobs:
         docker rm gcrun
 
     - name: Configure ssh keys
-      if: github.actor == 'gammacombo'
+      if: ${{ github.repository_owner == 'gammacombo' }}
       uses: webfactory/ssh-agent@v0.2.0
       with:
         ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
 
     - name: Publish output (if not a fork PR)
-      if: github.actor == 'gammacombo'
+      if: ${{ github.repository_owner == 'gammacombo' && github.event.pull_request.head.repo.full_name == github.repository }} 
       run: |
         git clone git@github.com:gammacombo/gammacombo.github.io.git
         cp ci_logs/* gammacombo.github.io/assets/images/ci/
@@ -62,5 +62,5 @@ jobs:
         git push origin master
 
     - name: Print Info
-      if: github.actor == 'gammacombo'
+      if: ${{ github.repository_owner == 'gammacombo' }}
       run: echo "Success. Check your CI tests at https://gammacombo.github.io/ci.html"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ option(BUILD_DOCUMENTATION
        "Create and install the HTML based API documentation (requires Doxygen)"
        OFF)
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 
 # Set build destinations. Cannot use CMAKE_LIBRARY_OUTPUT_DIRECTORY due to
@@ -48,7 +48,7 @@ include_directories(${Boost_INCLUDE_DIRS})
 
 # Find ROOT (see https://root.cern/manual/integrate_root_into_my_cmake_project/,
 # https://cliutils.gitlab.io/modern-cmake/chapters/packages/ROOT.html)
-find_package(ROOT 6.18 CONFIG REQUIRED)
+find_package(ROOT 6.30 CONFIG REQUIRED)
 message(STATUS "Found ROOT: ${ROOT_INCLUDE_DIRS}")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g3 -O3 ${ROOT_CXX_FLAGS}")
 message(STATUS "CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS}")

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,13 +2,22 @@ FROM rootproject/root:6.32.00-ubuntu22.04
 
 # Install dependencies
 RUN apt-get update && apt-get install -y \
-    build-essential \
+    software-properties-common && \
+    add-apt-repository ppa:ubuntu-toolchain-r/test && \
+    apt-get update && apt-get install -y \
+    gcc-13 \
+    g++-13 \
     cmake \
     nlohmann-json3-dev \
     libboost-all-dev \
     python3 \
-    python3-pip && \
-    apt-get clean
+    python3-pip \
+    libfmt-dev && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Make GCC 13 the default
+RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-13 100 && \
+    update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-13 100
 
 # Upgrade pip and install Python packages
 RUN pip3 install --upgrade pip

--- a/README.md
+++ b/README.md
@@ -35,8 +35,7 @@ session before running any executables.
 If `CVMFS` is not available or your OS is not supported,
 `scripts/setup-env-cvmfs.sh` will not work and you will have to setup a suitable
 working environment yourself (requires `CMake` 3.19 or higher, `ROOT` higher
-than v6.18 but below v34, `Boost`, and a compiler supporting the `C++17`
-standard).
+than v6.30, `Boost`, and a compiler supporting the `C++20` standard).
 
 To build the Doxygen documentation, which will create an HTML class documentation in
 the doc/html subdirectory, do:

--- a/core/include/Parameter.h
+++ b/core/include/Parameter.h
@@ -13,25 +13,29 @@
 
 class Parameter {
  public:
-  Parameter();
-  inline virtual ~Parameter(){};
+  virtual ~Parameter() = default;
+
   inline void setVal(double v) { startvalue = v; };
-  void Print();
+  void Print() const;
 
   struct Range {
     float min;
     float max;
   };
 
-  TString name;
-  TString title;
-  TString unit;
-  float startvalue;
-  Range phys;
-  Range scan;
-  Range force;
-  Range bboos;
-  Range free;
+ private:
+  const static Range default_range;
+
+ public:
+  TString name = "not initialized";
+  TString title = "not initialized";
+  TString unit = "not initialized";
+  double startvalue = 0.;
+  Range phys = default_range;
+  Range scan = default_range;
+  Range force = default_range;
+  Range bboos = default_range;
+  [[deprecated]] Range free = default_range;
 };
 
 #endif

--- a/core/include/Utils.h
+++ b/core/include/Utils.h
@@ -66,6 +66,10 @@ namespace Utils {
   // drawing HFAG label
   void HFAGLabel(const TString& label = "please set label", Double_t xpos = 0, Double_t ypos = 0, Double_t scale = 1);
 
+  // Very basic logging functions
+  void errBase(const std::string& prefix, const std::string& msg, bool exit = true);
+  void msgBase(const std::string& prefix, const std::string& msg, std::ostream& stream = std::cout);
+
   enum histogramType { kChi2, kPvalue };
   inline double sq(double x) { return x * x; }
   inline double RadToDeg(double rad) { return rad / TMath::Pi() * 180.; }

--- a/core/src/GammaComboEngine.cpp
+++ b/core/src/GammaComboEngine.cpp
@@ -48,6 +48,7 @@
 #include <fstream>
 #include <iostream>
 #include <map>
+#include <string.h>
 #include <string>
 #include <vector>
 
@@ -75,9 +76,13 @@ GammaComboEngine::GammaComboEngine(TString name, int argc, char* argv[]) : runOn
   m_batchscriptwriter = new BatchScriptWriter(argc, argv);
 
   // run ROOT in interactive mode, if requested (-i)
-  if (arg->interactive)
+  if (arg->interactive) {
+    // -a is a reserved option for TApplication
+    std::string actionStr = "--action";  // (needed to avoid compiler warnings)
+    for (int i = 2; i < argc; ++i)
+      if (!strcmp(argv[i], "-a")) { argv[i] = actionStr.data(); }
     theApp = new TApplication("App", &argc, argv);
-  else
+  } else
     gROOT->SetBatch(false);
 
   // initialize members

--- a/core/src/MethodPluginScan.cpp
+++ b/core/src/MethodPluginScan.cpp
@@ -968,9 +968,9 @@ TH1F* MethodPluginScan::analyseToys(ToyTree* t, int id, bool quiet) {
     float bestfitpoint = hCL->GetBinCenter(iBinBestFit);
     if (getSolution()) {
       bestfitpoint = getSolution()->getFloatParFinalVal(scanVar1);
-      if (isnan(bestfitpoint)) {
+      if (std::isnan(bestfitpoint)) {
         bestfitpoint = getSolution()->getConstParVal(scanVar1);
-        if (isnan(bestfitpoint)) { bestfitpoint = hCL->GetBinCenter(iBinBestFit); }
+        if (std::isnan(bestfitpoint)) { bestfitpoint = hCL->GetBinCenter(iBinBestFit); }
       }
     } else
       std::cout << "WARNING: No solution found, will approximate to the best scan point" << std::endl;

--- a/core/src/Parameter.cpp
+++ b/core/src/Parameter.cpp
@@ -1,28 +1,17 @@
 #include <Parameter.h>
 
+#include <format>
 #include <iostream>
 
-Parameter::Parameter() {
-  name = "not initialized";
-  title = "not initialized";
-  unit = "not initialized";
-  startvalue = 0;
-  Parameter::Range r = {-1e4, 1e4};
-  free = r;
-  phys = r;
-  scan = r;
-  force = r;
-  bboos = r;
-}
+const Parameter::Range Parameter::default_range = {-1e4, 1e4};
 
-void Parameter::Print() {
-  std::cout << " name       = " << name << std::endl;
-  std::cout << " title      = " << title << std::endl;
-  std::cout << " unit       = " << unit << std::endl;
-  std::cout << " startvalue = " << startvalue << std::endl;
-  std::cout << " phys       = " << phys.min << " ... " << phys.max << std::endl;
-  std::cout << " scan       = " << scan.min << " ... " << scan.max << std::endl;
-  std::cout << " force      = " << force.min << " ... " << force.max << std::endl;
-  std::cout << " bboos      = " << bboos.min << " ... " << bboos.max << std::endl;
-  std::cout << " free       = " << free.min << " ... " << free.max << std::endl;
+void Parameter::Print() const {
+  std::cout << std::format(" name       = {:s}\n", name.Data());
+  std::cout << std::format(" title      = {:s}\n", title.Data());
+  std::cout << std::format(" unit       = {:s}\n", unit.Data());
+  std::cout << std::format(" startvalue = {:f}\n", startvalue)
+            << std::format(" phys       = {:f} ... {:f}\n", phys.min, phys.max)
+            << std::format(" scan       = {:f} ... {:f}\n", scan.min, scan.max)
+            << std::format(" force      = {:f} ... {:f}\n", force.min, force.max)
+            << std::format(" bboos      = {:f} ... {:f}", bboos.min, bboos.max) << std::endl;
 }

--- a/core/src/Utils.cpp
+++ b/core/src/Utils.cpp
@@ -37,14 +37,46 @@
 #include <algorithm>
 #include <cassert>
 #include <cstdio>
+#include <cstdlib>
+#include <format>
 #include <iostream>
 #include <map>
 #include <string>
 #include <utility>
 #include <vector>
 
+namespace {
+  /// Replace all occurrences of a substring in a string.
+  std::string replaceAll(const std::string& input, const std::string& toReplace, const std::string& replaceWith) {
+    std::string output = input;
+    if (toReplace == replaceWith) return input;
+    size_t pos = 0;
+    size_t start_pos = 0;
+    do {
+      pos = output.find(toReplace, start_pos);
+      if (pos != std::string::npos) {
+        output.replace(pos, toReplace.length(), replaceWith);
+        start_pos = pos + toReplace.length();
+      }
+    } while (pos != std::string::npos);
+    return output;
+  }
+}  // namespace
+
 int Utils::countFitBringBackAngle;     ///< counts how many times an angle needed to be brought back
 int Utils::countAllFitBringBackAngle;  ///< counts how many times fitBringBackAngle() was called
+
+void Utils::errBase(const std::string& prefix, const std::string& msg, bool exit) {
+  const std::string endStringSeparator = msg.ends_with('\n') ? "" : ". ";
+  msgBase(prefix, msg + (exit ? endStringSeparator + "Exit..." : ""), std::cerr);
+  if (exit) { std::exit(1); }
+};
+
+void Utils::msgBase(const std::string& prefix, const std::string& msg, std::ostream& stream) {
+  auto prefixLength = std::ranges::count_if(prefix, [](char c) { return c != '\n'; });
+  auto msgOut = replaceAll(msg, "\n", "\n" + std::string(prefixLength, ' '));
+  stream << prefix << msgOut << std::endl;
+};
 
 ///
 /// Fit PDF to minimum.

--- a/core/src/Utils.cpp
+++ b/core/src/Utils.cpp
@@ -674,43 +674,52 @@ void Utils::floatParameters(const RooAbsCollection* set) {
   for (const auto& p : *set) static_cast<RooRealVar*>(p)->setConstant(false);
 }
 
+namespace {
+  inline void setLimitHelper(RooRealVar* v, const TString limitname) {
+    if (limitname == "free")
+      v->removeRange();
+    else
+      v->setRange(v->getMin(limitname), v->getMax(limitname));
+  }
+}  // namespace
+
 ///
 /// Load a named parameter range for a certain parameter.
 ///
-/// \param v - The parameter which will get the limit set.
-/// \param limitname - Name of the limit to set.
+/// @param v         The parameter which will get the limit set.
+/// @param limitname Name of the limit to set.
 ///
 void Utils::setLimit(RooRealVar* v, TString limitname) {
   RooMsgService::instance().setGlobalKillBelow(RooFit::ERROR);
-  v->setRange(v->getMin(limitname), v->getMax(limitname));
+  setLimitHelper(v, limitname);
   RooMsgService::instance().setGlobalKillBelow(RooFit::INFO);
 }
 
 ///
-/// Load a named parameter range for a certain parameter,
-/// which is found inside a workspace.
+/// Load a named parameter range for a certain parameter, which is found inside a workspace.
 ///
-/// \param w - The workspace holding the parameter.
-/// \param parname - The name of the parameter.
-/// \param limitname - Name of the limit to set.
+/// @param w         The workspace holding the parameter.
+/// @param parname   The name of the parameter.
+/// @param limitname Name of the limit to set.
 ///
 void Utils::setLimit(RooWorkspace* w, TString parname, TString limitname) {
   RooMsgService::instance().setGlobalKillBelow(RooFit::ERROR);
-  w->var(parname)->setRange(w->var(parname)->getMin(limitname), w->var(parname)->getMax(limitname));
+  auto v = w->var(parname);
+  setLimitHelper(v, limitname);
   RooMsgService::instance().setGlobalKillBelow(RooFit::INFO);
 }
 
 ///
 /// Load a named parameter range for a list of parameters.
 ///
-/// \param set - The list holding the parameters.
-/// \param limitname - Name of the limit to set.
+/// @param set       The list holding the parameters.
+/// @param limitname Name of the limit to set.
 ///
 void Utils::setLimit(const RooAbsCollection* set, TString limitname) {
   RooMsgService::instance().setGlobalKillBelow(RooFit::ERROR);
   for (const auto& pAbs : *set) {
-    const auto p = static_cast<RooRealVar*>(pAbs);
-    p->setRange(p->getMin(limitname), p->getMax(limitname));
+    auto p = static_cast<RooRealVar*>(pAbs);
+    setLimitHelper(p, limitname);
   }
   RooMsgService::instance().setGlobalKillBelow(RooFit::INFO);
 }

--- a/scripts/run_ci_tests.py
+++ b/scripts/run_ci_tests.py
@@ -79,7 +79,7 @@ def check_dsets_dat(datf):
     f = open(datf)
     for line in f.readlines():
         if line.startswith("Nbkg"):
-            assert "4990.2" in line and "-71.7" in line and "71.7" in line
+            assert "4990.2" in line and "-71.8" in line and "71.8" in line
         if line.startswith("branchingRatio"):
             assert "   0.000000    -0.000000     0.000000" in line
         if line.startswith("exponent"):

--- a/tutorial/src/ParametersCartesian.cpp
+++ b/tutorial/src/ParametersCartesian.cpp
@@ -10,7 +10,6 @@ ParametersCartesian::ParametersCartesian() { defineParameters(); }
 ///
 ///  scan:      defines scan range (for Prob and Plugin methods)
 ///  phys:      physically allowed range (needs to be set!)
-///  free:  range applied when no boundary is required - set this far away from any possible value
 ///
 void ParametersCartesian::defineParameters() {
   using Utils::DegToRad;

--- a/tutorial/src/ParametersTutorial.cpp
+++ b/tutorial/src/ParametersTutorial.cpp
@@ -9,7 +9,6 @@ ParametersTutorial::ParametersTutorial() { defineParameters(); }
 ///
 ///  scan:      defines scan range (for Prob and Plugin methods)
 ///  phys:      physically allowed range (needs to be set!)
-///  free:  range applied when no boundary is required - set this far away from any possible value
 ///
 void ParametersTutorial::defineParameters() {
   Parameter* p = 0;
@@ -21,7 +20,6 @@ void ParametersTutorial::defineParameters() {
   p->scan = range(-2.5, 2.5);
   p->phys = range(-1e4, 1e4);  // to implement a Feldman-Cousins like forbidden region, set the allowed region here and
                                // use --pr
-  p->free = range(-1e4, 1e4);
 
   p = newParameter("b_gaus");
   p->title = "b_{Gaus}";
@@ -29,5 +27,4 @@ void ParametersTutorial::defineParameters() {
   p->unit = "";
   p->scan = range(-2, 4);
   p->phys = range(-1e4, 1e4);
-  p->free = range(-1e4, 1e4);
 }


### PR DESCRIPTION
Resurrect all tutorials (many were broken):
  * don't perform fits in 1D/2D scans if there are no free parameters (e.g. 1/2), but evaluate the NLL only
  * "free" range for parameters should not be set nor used — otherwise Minuit will perform a transformation of the parameter, which can lead the fit to not converge e.g. if the parameter value is close to zero. Will keep the members for backward compatibility, but will ignore them in the code
  * fix a but in the configuration of TApplication that led to failure when the `-a` option was passed to command line along with `-i` (`-a` is reserved by TApplication)
 
I took the opportunity to add very basic logging utility functions in `Utils.h`. These are useful to avoid verbose cout especially for classes where a lot of logging is used.

Depends on https://github.com/gammacombo/gammacombo/pull/271 (for clean Git history)