### PR TITLE
Fix constructor in MethodPluginScan

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v6.0.0
     hooks:
     -   id: trailing-whitespace
     -   id: end-of-file-fixer
@@ -17,12 +17,12 @@ repos:
     hooks:
     -   id: check-include-convention
 -   repo: https://github.com/pre-commit/mirrors-clang-format
-    rev: v16.0.6
+    rev: v21.1.8
     hooks:
     -   id: clang-format
         exclude: 'core/include/tclap'
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.12.0
+    rev: v0.14.10
     hooks:
     -   id: ruff
         args: [ --fix ]

--- a/core/include/ParametersAbs.h
+++ b/core/include/ParametersAbs.h
@@ -29,7 +29,7 @@ class ParametersAbs {
 
  protected:
   std::vector<Parameter*> m_parameters;
-  inline virtual void defineParameters(){};
+  inline virtual void defineParameters() {};
 };
 
 #endif

--- a/core/include/RooHistPdfAngleVar.h
+++ b/core/include/RooHistPdfAngleVar.h
@@ -14,7 +14,7 @@ class TObject;
 
 class RooHistPdfAngleVar : public RooAbsReal {
  public:
-  RooHistPdfAngleVar(){};
+  RooHistPdfAngleVar() {};
   RooHistPdfAngleVar(const char* name, const char* title, RooAbsReal& _xobs, RooAbsReal& _xth, RooAbsReal& _xshift);
   RooHistPdfAngleVar(const RooHistPdfAngleVar& other, const char* name = 0);
   virtual TObject* clone(const char* newname) const { return new RooHistPdfAngleVar(*this, newname); }

--- a/core/include/RooHistPdfVar.h
+++ b/core/include/RooHistPdfVar.h
@@ -14,7 +14,7 @@ class TObject;
 
 class RooHistPdfVar : public RooAbsReal {
  public:
-  RooHistPdfVar(){};
+  RooHistPdfVar() {};
   RooHistPdfVar(const char* name, const char* title, RooAbsReal& _xobs, RooAbsReal& _xth, RooAbsReal& _xshift);
   RooHistPdfVar(const RooHistPdfVar& other, const char* name = 0);
   virtual TObject* clone(const char* newname) const { return new RooHistPdfVar(*this, newname); }

--- a/core/include/RooMultiPdf.h
+++ b/core/include/RooMultiPdf.h
@@ -16,7 +16,7 @@ class TObject;
 class RooMultiPdf : public RooAbsPdf {
  public:
   enum PenatlyScheme { PVAL, AIC };
-  RooMultiPdf(){};
+  RooMultiPdf() {};
   RooMultiPdf(const char* name, const char* title, RooCategory&, const RooArgList& _c);
   RooMultiPdf(const RooMultiPdf& other, const char* name = 0);
   virtual TObject* clone(const char* newname) const { return new RooMultiPdf(*this, newname); }

--- a/core/include/RooPoly3Var.h
+++ b/core/include/RooPoly3Var.h
@@ -14,7 +14,7 @@ class TObject;
 
 class RooPoly3Var : public RooAbsReal {
  public:
-  RooPoly3Var(){};
+  RooPoly3Var() {};
   RooPoly3Var(const char* name, const char* title, RooAbsReal& _xobs, double& _p0, double& _p1, double& _p2,
               double& _p3);
   RooPoly3Var(const RooPoly3Var& other, const char* name = 0);

--- a/core/include/RooPoly4Var.h
+++ b/core/include/RooPoly4Var.h
@@ -14,7 +14,7 @@ class TObject;
 
 class RooPoly4Var : public RooAbsReal {
  public:
-  RooPoly4Var(){};
+  RooPoly4Var() {};
   RooPoly4Var(const char* name, const char* title, RooAbsReal& _xobs, double& _p0, double& _p1, double& _p2,
               double& _p3, double& _p4);
   RooPoly4Var(const RooPoly4Var& other, const char* name = 0);

--- a/core/src/MethodPluginScan.cpp
+++ b/core/src/MethodPluginScan.cpp
@@ -71,9 +71,9 @@ MethodPluginScan::MethodPluginScan(MethodProbScan* s) : MethodAbsScan(s->getComb
 /// Constructor, mainly to ensure compatibility with MethodDatasetsPluginScan
 ///
 MethodPluginScan::MethodPluginScan(MethodProbScan* s, PDF_Datasets* pdf, const OptParser* opt) : MethodAbsScan(opt) {
-  constructorHelper(s);
   obsName = pdf->getObsName();
   w = pdf->getWorkspace();
+  constructorHelper(s);
 };
 
 ///

--- a/core/src/PDF_Abs.cpp
+++ b/core/src/PDF_Abs.cpp
@@ -564,8 +564,8 @@ bool PDF_Abs::checkConsistency() const {
     if (pObsName != base + "_obs") {
       std::cout << "PDF_Abs::checkConsistency() : " << name << " : " << pTh->GetName()
                 << " doesn't match its observable." << std::endl;
-      std::cout << "                              Expected '" << base + "_obs"
-                << "'. Found '" << pObsName << "'." << std::endl;
+      std::cout << "                              Expected '" << base + "_obs" << "'. Found '" << pObsName << "'."
+                << std::endl;
       std::cout << "                              Check ordering of the 'theory' and 'observables' lists!" << std::endl;
       allOk = false;
     }


### PR DESCRIPTION
Fixes https://github.com/gammacombo/gammacombo/issues/280
This seems due to a wrong order in a MethodPluginScan constructor:
```
MethodPluginScan::MethodPluginScan(MethodProbScan* s, PDF_Datasets* pdf, const OptParser* opt) : MethodAbsScan(opt) {
  constructorHelper(s);
  obsName = pdf->getObsName();
  w = pdf->getWorkspace();
};
```
Moving `constructorHelper(s);` after `obsName` and `w` definition fixes it.