### PR TITLE
Add support for ROOT 6.38.04

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,12 +17,12 @@ repos:
     hooks:
     -   id: check-include-convention
 -   repo: https://github.com/pre-commit/mirrors-clang-format
-    rev: v21.1.8
+    rev: v22.1.5
     hooks:
     -   id: clang-format
         exclude: 'core/include/tclap'
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.14.10
+    rev: v0.15.13
     hooks:
     -   id: ruff
         args: [ --fix ]

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,8 +41,8 @@ else()
   message(STATUS "Could NOT find Ccache")
 endif()
 
-# Prefer dependencies from the active conda environment, or from the ROOT
-# prefix when ROOT_DIR is provided explicitly.
+# Prefer dependencies from the active conda environment, or from the ROOT prefix
+# when ROOT_DIR is provided explicitly.
 if(DEFINED ENV{CONDA_PREFIX} AND EXISTS "$ENV{CONDA_PREFIX}/lib")
   list(PREPEND CMAKE_PREFIX_PATH "$ENV{CONDA_PREFIX}")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,18 +41,38 @@ else()
   message(STATUS "Could NOT find Ccache")
 endif()
 
-find_package(Freetype REQUIRED)
+# Prefer dependencies from the active conda environment, or from the ROOT
+# prefix when ROOT_DIR is provided explicitly.
+if(DEFINED ENV{CONDA_PREFIX} AND EXISTS "$ENV{CONDA_PREFIX}/lib")
+  list(PREPEND CMAKE_PREFIX_PATH "$ENV{CONDA_PREFIX}")
+endif()
+if(ROOT_DIR)
+  get_filename_component(ROOT_PREFIX "${ROOT_DIR}/.." ABSOLUTE)
+  if(EXISTS "${ROOT_PREFIX}/lib")
+    list(PREPEND CMAKE_PREFIX_PATH "${ROOT_PREFIX}")
+  endif()
+endif()
 
 if(POLICY CMP0167)
   cmake_policy(SET CMP0167 NEW)
 endif()
-find_package(Boost 1.70 REQUIRED)
-include_directories(${Boost_INCLUDE_DIRS})
 
 # Find ROOT (see https://root.cern/manual/integrate_root_into_my_cmake_project/,
 # https://cliutils.gitlab.io/modern-cmake/chapters/packages/ROOT.html)
 find_package(ROOT 6.30 CONFIG REQUIRED)
 message(STATUS "Found ROOT: ${ROOT_INCLUDE_DIRS}")
+
+# ROOT from conda-forge depends on the graphics stack from the same prefix.  If
+# CMake finds the system Freetype first, linking mixes host and conda libraries.
+get_filename_component(ROOT_PREFIX "${ROOT_DIR}/.." ABSOLUTE)
+if(EXISTS "${ROOT_PREFIX}/lib")
+  list(PREPEND CMAKE_PREFIX_PATH "${ROOT_PREFIX}")
+endif()
+
+find_package(Freetype REQUIRED)
+find_package(Boost 1.70 REQUIRED)
+include_directories(${Boost_INCLUDE_DIRS})
+
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g3 -O3 ${ROOT_CXX_FLAGS}")
 message(STATUS "CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS}")
 
@@ -132,7 +152,7 @@ set(ROOT_REQUIRED_LIBS
 
 set(CORE_LIB "${PROJECT_NAME}Core")
 add_library(${CORE_LIB} SHARED ${CORE_LIB_SOURCES})
-target_link_libraries(${CORE_LIB} PUBLIC ${FREETYPE_LIBRARIES}
+target_link_libraries(${CORE_LIB} PUBLIC Freetype::Freetype
                                          ${ROOT_REQUIRED_LIBS})
 # For finding ConfigVersion.h
 target_include_directories(${CORE_LIB} PUBLIC ${CMAKE_BINARY_DIR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,7 +132,8 @@ set(ROOT_REQUIRED_LIBS
 
 set(CORE_LIB "${PROJECT_NAME}Core")
 add_library(${CORE_LIB} SHARED ${CORE_LIB_SOURCES})
-target_link_libraries(${CORE_LIB} ${FREETYPE_LIBRARIES} ${ROOT_REQUIRED_LIBS})
+target_link_libraries(${CORE_LIB} PUBLIC ${FREETYPE_LIBRARIES}
+                                         ${ROOT_REQUIRED_LIBS})
 # For finding ConfigVersion.h
 target_include_directories(${CORE_LIB} PUBLIC ${CMAKE_BINARY_DIR})
 

--- a/core/src/PDF_Abs.cpp
+++ b/core/src/PDF_Abs.cpp
@@ -9,6 +9,8 @@
 
 #include <Utils.h>
 
+#include <RooAbsData.h>
+#include <RooAbsPdf.h>
 #include <RooFitResult.h>
 #include <RooFormulaVar.h>
 #include <RooMinimizer.h>

--- a/core/src/Utils.cpp
+++ b/core/src/Utils.cpp
@@ -10,6 +10,8 @@
 #include <RooSlimFitResult.h>
 #include <rdtsc.h>
 
+#include <RooAbsPdf.h>
+#include <RooDataSet.h>
 #include <RooFitResult.h>
 #include <RooFormulaVar.h>
 #include <RooMinimizer.h>

--- a/environment.yml
+++ b/environment.yml
@@ -3,11 +3,11 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - python=3.9
+  - python=3.12
   - numpy
   - scipy
   - matplotlib
-  - root>=6.34
+  - root=6.38.04
   - freetype
   - cmake>=3.30
   - boost

--- a/tutorial/CMakeLists.txt
+++ b/tutorial/CMakeLists.txt
@@ -49,7 +49,7 @@ set(COMBINER_LIB_SOURCES
 
 set(COMBINER_LIB ${COMBINER_NAME}Components)
 add_library(${COMBINER_LIB} SHARED ${COMBINER_LIB_SOURCES})
-target_link_libraries(${COMBINER_LIB} ${CORE_LIB})
+target_link_libraries(${COMBINER_LIB} PRIVATE ${CORE_LIB})
 if(HAS_CUSTOMROOTOBJECTS)
   root_generate_dictionary(
     G__${COMBINER_LIB} ${COMBINER_DICTIONARY_SOURCES} MODULE ${COMBINER_LIB}
@@ -63,7 +63,7 @@ endif()
 set(COMBINER_LIBS ${COMBINER_LIB} ${CORE_LIB})
 foreach(exec ${COMBINER_EXECUTABLES})
   add_executable(${exec} ${COMBINER_MAIN_DIR}/${exec}.cpp)
-  target_link_libraries(${exec} ${COMBINER_LIBS})
+  target_link_libraries(${exec} PRIVATE ${COMBINER_LIBS})
 endforeach()
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
Dear @tpajero,

it would be great if this could be merged soon-ish, 
as LHCb is using now python 3.12 and ROOT 6.38.04 with cmake 3.30.5.

And there were a few small changes to be applied. 
At the same time I updated pre-commit, too and applied according changes.