### PR TITLE
Bugfixes and CMake improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,7 +45,6 @@ if(POLICY CMP0167)
   cmake_policy(SET CMP0167 NEW)
 endif()
 find_package(Boost 1.70 REQUIRED)
-include_directories(${Boost_INCLUDE_DIRS})
 
 # Find ROOT (see https://root.cern/manual/integrate_root_into_my_cmake_project/,
 # https://cliutils.gitlab.io/modern-cmake/chapters/packages/ROOT.html)
@@ -63,59 +62,58 @@ endif()
 
 # Build the core library ------------------------------------------------------
 
-set(CORE_INC_DIR core/include)
-include_directories(BEFORE ${CORE_INC_DIR})
-configure_file(${CORE_INC_DIR}/VersionConfig.h.in VersionConfig.h)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/core/include/VersionConfig.h.in
+               VersionConfig.h)
 
 set(CORE_LIB_SOURCES
-    ./core/src/BatchScriptWriter.cpp
-    ./core/src/CLInterval.cpp
-    ./core/src/CLIntervalMaker.cpp
-    ./core/src/CLIntervalPrinter.cpp
-    ./core/src/Combiner.cpp
-    ./core/src/ConfidenceContours.cpp
-    ./core/src/Contour.cpp
-    ./core/src/ControlPlots.cpp
-    ./core/src/ExternalScanWrapper.cpp
-    ./core/src/FileNameBuilder.cpp
-    ./core/src/FitResultCache.cpp
-    ./core/src/Fitter.cpp
-    ./core/src/GammaComboEngine.cpp
-    ./core/src/Graphviz.cpp
-    ./core/src/LatexMaker.cpp
-    ./core/src/MethodAbsScan.cpp
-    ./core/src/MethodBergerBoosScan.cpp
-    ./core/src/MethodCoverageScan.cpp
-    ./core/src/MethodDatasetsPluginScan.cpp
-    ./core/src/MethodDatasetsProbScan.cpp
-    ./core/src/MethodPluginScan.cpp
-    ./core/src/MethodProbScan.cpp
-    ./core/src/OneMinusClPlot2d.cpp
-    ./core/src/OneMinusClPlotAbs.cpp
-    ./core/src/OneMinusClPlot.cpp
-    ./core/src/OptParser.cpp
-    ./core/src/ParameterCache.cpp
-    ./core/src/Parameter.cpp
-    ./core/src/ParameterEvolutionPlotter.cpp
-    ./core/src/ParametersAbs.cpp
-    ./core/src/PDF_Abs.cpp
-    ./core/src/PDF_Datasets.cpp
-    ./core/src/ProgressBar.cpp
-    ./core/src/PullPlotter.cpp
-    ./core/src/PValueCorrection.cpp
-    ./core/src/RooBinned2DBicubicBase.cpp
-    ./core/src/RooCrossCorPdf.cpp
-    ./core/src/RooHistPdfAngleVar.cpp
-    ./core/src/RooHistPdfVar.cpp
-    ./core/src/RooMultiPdf.cpp
-    ./core/src/RooPoly3Var.cpp
-    ./core/src/RooPoly4Var.cpp
-    ./core/src/RooSlimFitResult.cpp
-    ./core/src/Rounder.cpp
-    ./core/src/SharedArray.cpp
-    ./core/src/ToyTree.cpp
-    ./core/src/UtilsConfig.cpp
-    ./core/src/Utils.cpp)
+    ${CMAKE_CURRENT_SOURCE_DIR}/core/src/BatchScriptWriter.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core/src/CLInterval.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core/src/CLIntervalMaker.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core/src/CLIntervalPrinter.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core/src/Combiner.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core/src/ConfidenceContours.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core/src/Contour.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core/src/ControlPlots.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core/src/ExternalScanWrapper.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core/src/FileNameBuilder.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core/src/FitResultCache.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core/src/Fitter.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core/src/GammaComboEngine.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core/src/Graphviz.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core/src/LatexMaker.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core/src/MethodAbsScan.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core/src/MethodBergerBoosScan.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core/src/MethodCoverageScan.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core/src/MethodDatasetsPluginScan.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core/src/MethodDatasetsProbScan.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core/src/MethodPluginScan.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core/src/MethodProbScan.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core/src/OneMinusClPlot2d.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core/src/OneMinusClPlotAbs.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core/src/OneMinusClPlot.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core/src/OptParser.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core/src/ParameterCache.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core/src/Parameter.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core/src/ParameterEvolutionPlotter.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core/src/ParametersAbs.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core/src/PDF_Abs.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core/src/PDF_Datasets.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core/src/ProgressBar.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core/src/PullPlotter.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core/src/PValueCorrection.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core/src/RooBinned2DBicubicBase.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core/src/RooCrossCorPdf.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core/src/RooHistPdfAngleVar.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core/src/RooHistPdfVar.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core/src/RooMultiPdf.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core/src/RooPoly3Var.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core/src/RooPoly4Var.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core/src/RooSlimFitResult.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core/src/Rounder.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core/src/SharedArray.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core/src/ToyTree.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core/src/UtilsConfig.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/core/src/Utils.cpp)
 
 set(ROOT_REQUIRED_LIBS
     ROOT::Core
@@ -130,9 +128,11 @@ set(ROOT_REQUIRED_LIBS
 
 set(CORE_LIB "${PROJECT_NAME}Core")
 add_library(${CORE_LIB} SHARED ${CORE_LIB_SOURCES})
-target_link_libraries(${CORE_LIB} ${ROOT_REQUIRED_LIBS})
-# For finding ConfigVersion.h
-target_include_directories(${CORE_LIB} PUBLIC ${CMAKE_BINARY_DIR})
+target_link_libraries(${CORE_LIB} PUBLIC ${ROOT_REQUIRED_LIBS} Boost::boost)
+# CMAKE_BINARY_DIR needed for finding ConfigVersion.h
+target_include_directories(
+  ${CORE_LIB} PUBLIC ${CMAKE_BINARY_DIR}
+                     ${CMAKE_CURRENT_SOURCE_DIR}/core/include)
 
 # Add ROOT dictionaries to the core library, see:
 # https://cliutils.gitlab.io/modern-cmake/chapters/packages/ROOT.html#dictionary-generation
@@ -147,8 +147,9 @@ set(CORE_DICTIONARY_SOURCES
     RooPoly4Var.h
     RooSlimFitResult.h
     RooMultiPdf.h)
-root_generate_dictionary(G__${CORE_LIB} ${CORE_DICTIONARY_SOURCES} MODULE
-                         ${CORE_LIB} LINKDEF core/include/coreLinkDef.h)
+root_generate_dictionary(
+  G__${CORE_LIB} ${CORE_DICTIONARY_SOURCES} MODULE ${CORE_LIB} LINKDEF
+  ${CMAKE_CURRENT_SOURCE_DIR}/core/include/coreLinkDef.h)
 
 install(FILES ${CMAKE_BINARY_DIR}/lib${CORE_LIB}_rdict.pcm
         DESTINATION ${LIBRARY_OUTPUT_DIRECTORY})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,8 +41,6 @@ else()
   message(STATUS "Could NOT find Ccache")
 endif()
 
-find_package(Freetype REQUIRED)
-
 if(POLICY CMP0167)
   cmake_policy(SET CMP0167 NEW)
 endif()
@@ -132,7 +130,7 @@ set(ROOT_REQUIRED_LIBS
 
 set(CORE_LIB "${PROJECT_NAME}Core")
 add_library(${CORE_LIB} SHARED ${CORE_LIB_SOURCES})
-target_link_libraries(${CORE_LIB} ${FREETYPE_LIBRARIES} ${ROOT_REQUIRED_LIBS})
+target_link_libraries(${CORE_LIB} ${ROOT_REQUIRED_LIBS})
 # For finding ConfigVersion.h
 target_include_directories(${CORE_LIB} PUBLIC ${CMAKE_BINARY_DIR})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -158,7 +158,6 @@ install(FILES ${CMAKE_BINARY_DIR}/lib${CORE_LIB}_rdict.pcm
 
 # Set the list of output folders that should be created by each submodule
 set(OUTPUT_FOLDERS
-    root
     plots
     plots/C
     plots/cl

--- a/core/src/Combiner.cpp
+++ b/core/src/Combiner.cpp
@@ -393,7 +393,8 @@ void Combiner::adjustPhysRange(TString varName, double min, double max) {
     return;
   }
   if (min <= -999. && max <= -999.) {
-    w->var(varName)->removeRange();
+    w->var(varName)->removeMin();
+    w->var(varName)->removeMax();
   } else {
     w->var(varName)->setRange("phys", min, max);
   }

--- a/core/src/GammaComboEngine.cpp
+++ b/core/src/GammaComboEngine.cpp
@@ -1580,7 +1580,11 @@ void GammaComboEngine::adjustRanges(Combiner* c, int cId) {
   if (cId < arg->removeRanges.size()) {
     for (int j = 0; j < arg->removeRanges[cId].size(); j++) {
       if (arg->removeRanges[cId][j] == "all") {
-        for (const auto& par : *c->getParameters()) static_cast<RooRealVar*>(par)->removeRange();
+        for (const auto& par : *c->getParameters()) {
+          auto p = static_cast<RooRealVar*>(par);
+          p->removeMin();
+          p->removeMax();
+        }
       } else {
         c->adjustPhysRange(arg->removeRanges[cId][j], -999, -999);
       }

--- a/core/src/PDF_Abs.cpp
+++ b/core/src/PDF_Abs.cpp
@@ -9,6 +9,8 @@
 
 #include <Utils.h>
 
+#include <RooAbsData.h>
+#include <RooAbsPdf.h>
 #include <RooFitResult.h>
 #include <RooFormulaVar.h>
 #include <RooMinimizer.h>

--- a/core/src/Utils.cpp
+++ b/core/src/Utils.cpp
@@ -10,6 +10,9 @@
 #include <RooSlimFitResult.h>
 #include <rdtsc.h>
 
+#include <RooAbsPdf.h>
+#include <RooArgSet.h>
+#include <RooDataSet.h>
 #include <RooFitResult.h>
 #include <RooFormulaVar.h>
 #include <RooMinimizer.h>
@@ -679,9 +682,10 @@ void Utils::floatParameters(const RooAbsCollection* set) {
 
 namespace {
   inline void setLimitHelper(RooRealVar* v, const TString limitname) {
-    if (limitname == "free")
-      v->removeRange();
-    else
+    if (limitname == "free") {
+      v->removeMin();
+      v->removeMax();
+    } else
       v->setRange(v->getMin(limitname), v->getMax(limitname));
   }
 }  // namespace

--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - python=3.9
+  - python=>3.9
   - numpy
   - scipy
   - matplotlib

--- a/tutorial/CMakeLists.txt
+++ b/tutorial/CMakeLists.txt
@@ -28,8 +28,6 @@ set(COMBINER_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/include)
 set(COMBINER_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/src)
 set(COMBINER_MAIN_DIR ${CMAKE_CURRENT_SOURCE_DIR}/main)
 
-include_directories(BEFORE ${CORE_INC_DIR} ${COMBINER_INCLUDE_DIR})
-
 # -----------------------------------------------------------------------------
 # Build the library
 # -----------------------------------------------------------------------------
@@ -49,7 +47,8 @@ set(COMBINER_LIB_SOURCES
 
 set(COMBINER_LIB ${COMBINER_NAME}Components)
 add_library(${COMBINER_LIB} SHARED ${COMBINER_LIB_SOURCES})
-target_link_libraries(${COMBINER_LIB} ${CORE_LIB})
+target_link_libraries(${COMBINER_LIB} PUBLIC ${CORE_LIB})
+target_include_directories(${COMBINER_LIB} PUBLIC ${COMBINER_INCLUDE_DIR})
 if(HAS_CUSTOMROOTOBJECTS)
   root_generate_dictionary(
     G__${COMBINER_LIB} ${COMBINER_DICTIONARY_SOURCES} MODULE ${COMBINER_LIB}
@@ -60,10 +59,9 @@ endif()
 # Build the executables
 # -----------------------------------------------------------------------------
 
-set(COMBINER_LIBS ${COMBINER_LIB} ${CORE_LIB})
 foreach(exec ${COMBINER_EXECUTABLES})
   add_executable(${exec} ${COMBINER_MAIN_DIR}/${exec}.cpp)
-  target_link_libraries(${exec} ${COMBINER_LIBS})
+  target_link_libraries(${exec} PUBLIC ${COMBINER_LIB})
 endforeach()
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
- C++ bugfixes:
  - add a few missing RooFit headers causing compilation failures
  - substitute deprecated `removeRange` method (to be removed from future ROOT releases) with `remove<Min/Max>`
- avoid strict specification of Python version in `environment.yml`
- CMake improvements:
  - be explicit about `PUBLIC/PRIVATE` linking of libraries in CMake (causing configuration failure in modern CMake versions)
  - remove dependence on Freetype libraries
  - avoid `include_directories` calls