### PR TITLE
Fix CMake compatibility with Conda Boost and ROOT

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,7 +44,9 @@ endif()
 find_package(Freetype REQUIRED)
 
 if(POLICY CMP0167)
-  cmake_policy(SET CMP0167 NEW)
+  # Boost packages do not universally ship BoostConfig.cmake (notably some
+  # Conda environments). Keep CMake's FindBoost module as a fallback.
+  cmake_policy(SET CMP0167 OLD)
 endif()
 find_package(Boost 1.70 REQUIRED)
 include_directories(${Boost_INCLUDE_DIRS})
@@ -131,7 +133,8 @@ set(ROOT_REQUIRED_LIBS
 
 set(CORE_LIB "${PROJECT_NAME}Core")
 add_library(${CORE_LIB} SHARED ${CORE_LIB_SOURCES})
-target_link_libraries(${CORE_LIB} ${FREETYPE_LIBRARIES} ${ROOT_REQUIRED_LIBS})
+target_link_libraries(${CORE_LIB} PUBLIC ${FREETYPE_LIBRARIES}
+                                         ${ROOT_REQUIRED_LIBS})
 # For finding ConfigVersion.h
 target_include_directories(${CORE_LIB} PUBLIC ${CMAKE_BINARY_DIR})
 


### PR DESCRIPTION
This fixes CMake configuration with Conda environments that provide Boost
without a `BoostConfig.cmake` file by retaining CMake's `FindBoost` fallback.
It also updates `GammaComboCore` to use keyword-style linking, ensuring
compatibility with ROOT's current dictionary-generation macros.

Tested with Boost 1.82 and ROOT 6.38 from the `root_forge` environment.
