### PR TITLE
Fix CMake compatibility with Conda Boost and ROOT

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,8 +42,8 @@ else()
 endif()
 
 if(POLICY CMP0167)
-  # Boost packages do not universally ship BoostConfig.cmake (notably some
-  # Conda environments). Keep CMake's FindBoost module as a fallback.
+  # Boost packages do not universally ship BoostConfig.cmake (notably some Conda
+  # environments). Keep CMake's FindBoost module as a fallback.
   cmake_policy(SET CMP0167 OLD)
 endif()
 find_package(Boost 1.70 REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,7 +42,9 @@ else()
 endif()
 
 if(POLICY CMP0167)
-  cmake_policy(SET CMP0167 NEW)
+  # Boost packages do not universally ship BoostConfig.cmake (notably some
+  # Conda environments). Keep CMake's FindBoost module as a fallback.
+  cmake_policy(SET CMP0167 OLD)
 endif()
 find_package(Boost 1.70 REQUIRED)
 


### PR DESCRIPTION
This fixes CMake configuration in Conda environments that provide Boost
without a `BoostConfig.cmake` file. It retains CMake's `FindBoost` fallback,
allowing GammaCombo to find and use the available Boost headers.

Tested with Boost 1.82 and ROOT 6.38 from the `root_forge` environment.

