### PR TITLE
Fix CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -21,6 +21,8 @@ variables:
   NO_LBLOGIN: "1"
   GIT_SUBMODULE_STRATEGY: none
   CHARM_BRANCH: main
+  CONFIG_FILE_WS: config/plotting/ws-2025.py
+  CONFIG_FILE: config/plotting/charm-2025.py
 
 check-formatting:
   stage: pre-commit
@@ -143,10 +145,11 @@ test-charm:
       python -m pip install -e . -e charm-fitter
       cd charm-fitter
   script:
-    - python scripts/BLUE/python/dy.py -c wa-2024 --fs all
-    - python scripts/BLUE/python/d-to-etah.py -c 2025
-    - python scripts/BLUE/python/d0-to-ksks.py -c 2025
-    - python scripts/mpl-plots.py -a 1d --config config/plotting/2025.py --rescan --no-latex
+    - python scripts/BLUE/python/dy.py -c wa-2024 --fs all --no-latex
+    - python scripts/BLUE/python/d-to-etah.py -c 2025 --no-latex
+    - python scripts/BLUE/python/d0-to-ksks.py -c 2025 --no-latex
+    - python scripts/ws-combo.py -a all --rescan --no-latex --config ${CONFIG_FILE_WS}
+    - python scripts/charm-combo.py -a all --rescan --no-latex --config ${CONFIG_FILE}
   artifacts:
     when: always
     paths:

--- a/core/src/GammaComboEngine.cpp
+++ b/core/src/GammaComboEngine.cpp
@@ -353,9 +353,8 @@ std::vector<int> GammaComboEngine::getCombinersIds() const {
 ///
 PDF_Abs* GammaComboEngine::getPdf(int id) {
   if (!pdfExists(id)) {
-    std::cout << "GammaComboEngine::getPdf() : ERROR : Requested PDF id doesn't exist in GammaComboEngine. Exit."
-              << std::endl;
-    std::exit(1);
+    auto error = [](std::string msg) { return Utils::errBase("GammaComboEngine::getPdf ERROR ", msg); };
+    error(std::format("PDF id \"{}\" doesn't exist in GammaComboEngine", id));
   }
   return pdf[id];
 }

--- a/core/src/MethodProbScan.cpp
+++ b/core/src/MethodProbScan.cpp
@@ -592,6 +592,7 @@ int MethodProbScan::scan2d() {
 
         RooSlimFitResult* sfr = nullptr;
         auto chi2minScan = std::numeric_limits<double>::max();
+        bool fitConverged = true;
         bool performFit = hasFreePars;
         if (!hasFreePars) {
           // There are no parameters to fit, just calculate NLL
@@ -613,6 +614,12 @@ int MethodProbScan::scan2d() {
           chi2minScan = fr->minNll();
           if (std::isinf(chi2minScan))
             chi2minScan = std::numeric_limits<double>::max();  // else the toys in PDF_testConstraint don't work
+          // A fit that didn't converge can report a spuriously low minNll(); don't let such a
+          // result move the global minimum or overwrite a previously converged fit.
+          fitConverged = fr->status() == 0 && fr->edm() < 1;
+          if (!fitConverged && arg->debug)
+            std::cout << "MethodProbScan::scan2d() : WARNING : fit didn't converge at (" << i << "," << j
+                      << "): status=" << fr->status() << " edm=" << fr->edm() << " minNll=" << chi2minScan << std::endl;
           tFit.Stop();
           tSlimResult.Start(false);
           allResults.push_back(new RooSlimFitResult(fr.get()));  // save memory by using the slim fit result
@@ -624,12 +631,11 @@ int MethodProbScan::scan2d() {
             par2->setConstant(true);
           }
         }
-        bestMinFoundInScan = std::min(chi2minScan, bestMinFoundInScan);
+        if (fitConverged) bestMinFoundInScan = std::min(chi2minScan, bestMinFoundInScan);
 
-        // If we find a new global minumum, this means that all
-        // previous 1-CL values are too high. We'll save the new possible solution, adjust the global
-        // minimum, return a status code, and stop.
-        if (chi2minScan > -500 && chi2minScan < chi2minGlobal) {
+        // If we find a new global minumum, this means that all previous 1-CL values are too high.
+        // We'll save the new possible solution, adjust the global minimum, return a status code, and stop.
+        if (fitConverged && chi2minScan > -500.0 && chi2minScan < chi2minGlobal) {
           // warn only if there was a significant improvement
           if (arg->debug || chi2minScan < chi2minGlobal - 1e-2) {
             if (arg->verbose)
@@ -648,8 +654,10 @@ int MethodProbScan::scan2d() {
         double deltaChi2 = chi2minScan - chi2minGlobal;
         double oneMinusCL = TMath::Prob(deltaChi2, ndof);
 
-        // Save the 1-CL value. But only if better than before!
-        if (hCL2d->GetBinContent(i, j) < oneMinusCL) {
+        // Save the 1-CL value. But only if better than before, and only if the fit that produced
+        // it actually converged (an unconverged fit can report a spuriously low minNll(), which would
+        // otherwise silently overwrite a meaningful value from a previous scan).
+        if (fitConverged && hCL2d->GetBinContent(i, j) < oneMinusCL) {
           hCL2d->SetBinContent(i, j, oneMinusCL);
           hChi2min2d->SetBinContent(i, j, chi2minScan);
           hDbgChi2min2d->SetBinContent(i, j, chi2minScan);

--- a/core/src/ParameterCache.cpp
+++ b/core/src/ParameterCache.cpp
@@ -4,6 +4,7 @@
 #include <MethodAbsScan.h>
 #include <OptParser.h>
 #include <RooSlimFitResult.h>
+#include <Utils.h>
 
 #include <RooRealVar.h>
 #include <RooWorkspace.h>
@@ -17,6 +18,7 @@
 
 #include <cassert>
 #include <cstdlib>
+#include <format>
 #include <fstream>
 #include <iostream>
 #include <map>
@@ -147,14 +149,15 @@ void ParameterCache::cacheParameters(MethodAbsScan* scanner, TString fileName) {
 /// \return - true, if a file was loaded
 ///
 bool ParameterCache::loadPoints(TString fileName) {
+  auto info = [](std::string msg) { return Utils::msgBase("ParameterCache::loadPoints INFO ", msg); };
+  auto error = [](std::string msg) { return Utils::errBase("ParameterCache::loadPoints ERROR ", msg); };
 
   bool successfullyLoaded = false;
   startingValues.clear();
 
   std::ifstream infile(fileName.Data());
   if (infile) {  // file exists
-    if (m_arg && m_arg->debug)
-      std::cout << "ParameterCache::loadPoints() -- loading parameters from file " << fileName << std::endl;
+    if (m_arg && m_arg->debug) info(std::format("Loading parameters from file \"{}\"", fileName.Data()));
     std::string line;
     if (infile.is_open()) {
       int nSolutions = 0;
@@ -167,6 +170,11 @@ bool ParameterCache::loadPoints(TString fileName) {
           nSolutions++;
           startingValues.push_back(std::map<TString, double>());
         } else {
+          if (nSolutions == 0) {
+            error(std::format(
+                "File \"{}\" has a parameter line before any \"----- SOLUTION ... -----\" separator line: \"{}\"",
+                fileName.Data(), line));
+          }
           std::vector<std::string> els;
           boost::split(els, line, boost::is_any_of(" "), boost::token_compress_on);
           TString name = els[0];

--- a/core/src/gc_core/mpl_tools.py
+++ b/core/src/gc_core/mpl_tools.py
@@ -153,10 +153,12 @@ def read_gc_scan(scanfile, parfile, pars):
         )
 
     # get chi2 distribution
-    tf = r.TFile(scanfile)
-    # tf.ls()
-    h = tf.Get("hChi2min").Clone()
-    # h.Print()
+    tf = r.TFile.Open(scanfile)
+    h = tf.Get("hChi2min")
+    if not h:
+        raise RuntimeError("No 'hChi2min' found in", scanfile)
+    # Detach from file so it survives tf.Close() (avoids a cppyy dealloc crash)
+    h.SetDirectory(0)
 
     if h is None:
         raise RuntimeError("No 'hChi2min' found in", scanfile)
@@ -704,6 +706,7 @@ def plot2d(
     fopts=[],
     mopts=[],
     title=[None, None],
+    labelpad: tuple[float, float] | float = (4.0, 4.0),
     levels=1,
     legtitles=None,
     angle=[False, False],
@@ -853,9 +856,11 @@ def plot2d(
 
     # style
     if title[0]:
-        ax.set_xlabel(title[0])
+        ax.set_xlabel(
+            title[0], labelpad=labelpad if isinstance(labelpad, int) else labelpad[0]
+        )
     if title[1]:
-        ax.set_ylabel(title[1])
+        ax.set_ylabel(title[1], labelpad=labelpad[1])
 
     # add logos
     if logo:
@@ -1270,6 +1275,3 @@ class plotter:
 
         fig.savefig(self.save)
         fig.savefig(self.save.replace("pdf", "png"))
-
-        # if not args.interactive:
-        #     fig.clf()


### PR DESCRIPTION
- Fix CI by passing the --no-latex option to all python scripts
- Bugfixes for:
  -  loading ParameterCache from .dat file
  - 2D scans where failed scans in the second, third etc scans filled the chi2 with zero, replacing a good chi2 value found in the first scan
- Improve error logging for ParameterCache and GammaComboEngine
- Add option of having padding in plots axes